### PR TITLE
fix(candlestick): Fix hammer functions.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,3 +22,7 @@
 * Add optional `ratio` param to hammers.
 * Fix kickers to exclude hammers.
 * Fix candle wrapping on engulfings.
+
+# 0.0.6 / 2024-03-31
+* Remove optional param `ratio` from hammer functions causing bad results.
+* Fix `bullishHammer`, `bearishHammer`, `bullishInvertedHammer`, `bearishInvertedHammer`, and `hangingMan` functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "candlestick",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "candlestick",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "candlestick",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "JavaScript library for candlestick patterns detection.",
   "homepage": "https://github.com/cm45t3r/candlestick",
   "author": {

--- a/src/candlestick.js
+++ b/src/candlestick.js
@@ -147,11 +147,10 @@ function findPattern(dataArray, callback) {
  * 
  * @param {Object} candlestick - object with fields 
  *   `{ open: number, high: number, low: number, close: number }`
- * @param {number} ratio - minimum `tail:body` ratio on a hammer.
  * @return {boolean} a boolean.
  */
- function isHammer(candlestick, ratio = 2) {
-  return tailLen(candlestick) > (bodyLen(candlestick) * ratio) &&
+ function isHammer(candlestick) {
+  return tailLen(candlestick) > (bodyLen(candlestick) * 2) &&
     wickLen(candlestick) < bodyLen(candlestick);
 }
 
@@ -161,11 +160,10 @@ function findPattern(dataArray, callback) {
  * 
  * @param {Object} candlestick - object with fields 
  *   `{ open: number, high: number, low: number, close: number }`
- * @param {number} ratio - minimum `tail:body` ratio on a hammer.
  * @return {boolean} a boolean.
  */
-function isInvertedHammer(candlestick, ratio = 2) {
-  return wickLen(candlestick) > (bodyLen(candlestick) * ratio) &&
+function isInvertedHammer(candlestick) {
+  return wickLen(candlestick) > (bodyLen(candlestick) * 2) &&
     tailLen(candlestick) < bodyLen(candlestick);
 }
 
@@ -376,7 +374,7 @@ function invertedHammer(dataArray) {
  * @return {Array} array of matches.
  */
  function bullishHammer(dataArray) {
-  return findPattern(dataArray, isHammer);
+  return findPattern(dataArray, isBullishHammer);
 }
 
 /**
@@ -387,7 +385,7 @@ function invertedHammer(dataArray) {
  * @return {Array} array of matches.
  */
  function bearishHammer(dataArray) {
-  return findPattern(dataArray, isHammer);
+  return findPattern(dataArray, isBearishHammer);
 }
 
 /**
@@ -398,7 +396,7 @@ function invertedHammer(dataArray) {
  * @return {Array} array of matches.
  */
  function bullishInvertedHammer(dataArray) {
-  return findPattern(dataArray, isHammer);
+  return findPattern(dataArray, isBullishInvertedHammer);
 }
 
 /**
@@ -409,7 +407,7 @@ function invertedHammer(dataArray) {
  * @return {Array} array of matches.
  */
  function bearishInvertedHammer(dataArray) {
-  return findPattern(dataArray, isHammer);
+  return findPattern(dataArray, isBearishInvertedHammer);
 }
 
 /**
@@ -420,7 +418,7 @@ function invertedHammer(dataArray) {
  * @return {Array} array of matches.
  */
 function hangingMan(dataArray) {
-  return findPattern(dataArray, isShootingStar);
+  return findPattern(dataArray, isHangingMan);
 }
 
 /**


### PR DESCRIPTION
* Remove optional param `ratio` from hammer functions causing bad results.
* Fix `bullishHammer`, `bearishHammer`, `bullishInvertedHammer`, `bearishInvertedHammer`, and `hangingMan` functions.