### PR TITLE
fix(#12): Some Patterns return undefined

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,3 +26,4 @@
 # 0.0.6 / 2024-03-31
 * Remove optional param `ratio` from hammer functions causing bad results.
 * Fix `bullishHammer`, `bearishHammer`, `bullishInvertedHammer`, `bearishInvertedHammer`, and `hangingMan` functions.
+* Bugfix [#1](https://github.com/cm45t3r/candlestick/issues/1).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ npm install --save candlestick
 
 **Note:** OHLC objects can have more fields and does not affect the final result.
 
+**=== :warning: BREAKING CHANGE WARNING ON VERSIONS <= 0.0.6 ===**
+
+**Before:** search pattern functions returned the *last* OHLC object conforming the pattern.
+**After:** they return the *first* **index** of the candle conforming the pattern. It helps 
+locating candlestick in `dataArray` more easily. So before upgrading to version 0.0.6, please 
+be aware of changing your code.
+
 
 ## Examples
 

--- a/src/candlestick.js
+++ b/src/candlestick.js
@@ -117,25 +117,19 @@ function hasGapDown(previous, current) {
 
 // Dynamic array search for callback arguments.
 function findPattern(dataArray, callback) {
-  const upperBound = (dataArray.length - callback.length) + 1;
-  const matches = [];
+  const paramCount = callback.length;
+  const upperBound = dataArray.length - paramCount;
+  const results = [];
 
-  for (let i = 0; i < upperBound; i++) {
-    const args = [];
+  for (let i = 0; i <= upperBound; i++) {
+    const values = dataArray.slice(i, i + paramCount);
 
-    // Read the leftmost j values at position i in array.
-    // The j values are callback arguments.
-    for (let j = 0; j < callback.length; j++) {
-      args.push(dataArray[i + j]);
-    }
-
-    // Destructure args and find matches.
-    if (callback(...args)) {
-      matches.push(args[1]);
+    if (callback(...values)) {
+      results.push(i);
     }
   }
 
-  return matches;
+  return results;
 }
 
 // Boolean pattern detection.
@@ -149,7 +143,7 @@ function findPattern(dataArray, callback) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {boolean} a boolean.
  */
- function isHammer(candlestick) {
+function isHammer(candlestick) {
   return tailLen(candlestick) > (bodyLen(candlestick) * 2) &&
     wickLen(candlestick) < bodyLen(candlestick);
 }
@@ -186,7 +180,7 @@ function isBullishHammer(candlestick) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {boolean} a boolean.
  */
- function isBearishHammer(candlestick) {
+function isBearishHammer(candlestick) {
   return isBearish(candlestick) &&
     isHammer(candlestick);
 }
@@ -210,7 +204,7 @@ function isBullishInvertedHammer(candlestick) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {boolean} a boolean.
  */
- function isBearishInvertedHammer(candlestick) {
+function isBearishInvertedHammer(candlestick) {
   return isBearish(candlestick) &&
     isInvertedHammer(candlestick);
 }
@@ -373,7 +367,7 @@ function invertedHammer(dataArray) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {Array} array of matches.
  */
- function bullishHammer(dataArray) {
+function bullishHammer(dataArray) {
   return findPattern(dataArray, isBullishHammer);
 }
 
@@ -384,7 +378,7 @@ function invertedHammer(dataArray) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {Array} array of matches.
  */
- function bearishHammer(dataArray) {
+function bearishHammer(dataArray) {
   return findPattern(dataArray, isBearishHammer);
 }
 
@@ -395,7 +389,7 @@ function invertedHammer(dataArray) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {Array} array of matches.
  */
- function bullishInvertedHammer(dataArray) {
+function bullishInvertedHammer(dataArray) {
   return findPattern(dataArray, isBullishInvertedHammer);
 }
 
@@ -406,7 +400,7 @@ function invertedHammer(dataArray) {
  *   `{ open: number, high: number, low: number, close: number }`
  * @return {Array} array of matches.
  */
- function bearishInvertedHammer(dataArray) {
+function bearishInvertedHammer(dataArray) {
   return findPattern(dataArray, isBearishInvertedHammer);
 }
 

--- a/test/candlestick.test.js
+++ b/test/candlestick.test.js
@@ -89,51 +89,48 @@ describe('candlestick', () => {
   });
 
   describe('#bullishKicker()', () => {
-    it('should find bullish kickers at positions 2 and 7 in array', () => {
+    it('should find bullish kickers at positions 1 and 6 in array', () => {
       const data = [
-        {id: 0, open: 1, close: 2}, {id: 1, open: 2, close: 1},
-        {id: 2, open: 3, close: 4}, {id: 3, open: 6, close: 7},
-        {id: 4, open: 3, close: 6}, {id: 5, open: 4, close: 5},
-        {id: 6, open: 5, close: 3}, {id: 7, open: 7, close: 9},
+        { open: 1, close: 2 }, { open: 2, close: 1 },
+        { open: 3, close: 4 }, { open: 6, close: 7 },
+        { open: 3, close: 6 }, { open: 4, close: 5 },
+        { open: 5, close: 3 }, { open: 7, close: 9 },
       ];
-
-      const [r1, r2] = cs.bullishKicker(data).map((e) => e.id);
-      assert.equal(2, r1);
-      assert.equal(7, r2);
+      
+      const results = cs.bullishKicker(data);
+      assert.deepStrictEqual([1, 6], results);
     });
   });
 
   describe('#bearishKicker()', () => {
-    it('should find bearish kickers at positions 3 and 6 in array', () => {
+    it('should find bearish kickers at positions 2 and 5 in array', () => {
       const data = [
-        {id: 0, open: 5, close: 2}, {id: 1, open: 7, close: 8},
-        {id: 2, open: 3, close: 4}, {id: 3, open: 2, close: 1},
-        {id: 4, open: 3, close: 6}, {id: 5, open: 4, close: 5},
-        {id: 6, open: 2, close: 1}, {id: 7, open: 7, close: 9},
+        { open: 5, close: 2 }, { open: 7, close: 8 },
+        { open: 3, close: 4 }, { open: 2, close: 1 },
+        { open: 3, close: 6 }, { open: 4, close: 5 },
+        { open: 2, close: 1 }, { open: 7, close: 9 },
       ];
 
-      const [r1, r2] = cs.bearishKicker(data).map((e) => e.id);
-      assert.equal(3, r1);
-      assert.equal(6, r2);
+      const results = cs.bearishKicker(data);
+      assert.deepStrictEqual([2, 5], results);
     });
   });
 
   describe('#shootingStar()', () => {
-    it('should find shooting stars at positions 1 and 5 in array', () => {
+    it('should find shooting stars at positions 0 and 4 in array', () => {
       const data = [
-        {id: 0, open: 1, high: 10, low: 0.5, close: 2},
-        {id: 1, open: 4, high: 20, low: 2.9, close: 3},
-        {id: 2, open: 2, high: 10, low: 0.5, close: 1},
-        {id: 3, open: 2, high: 10, low: 0.5, close: 1},
-        {id: 4, open: 1, high: 10, low: 0.5, close: 2},
-        {id: 5, open: 4, high: 20, low: 2.9, close: 3},
-        {id: 6, open: 1, high: 10, low: 0.5, close: 2},
-        {id: 7, open: 3, high: 30, low: 1.4, close: 2},
+        { open: 1, high: 10, low: 0.5, close: 2},
+        { open: 4, high: 20, low: 2.9, close: 3},
+        { open: 2, high: 10, low: 0.5, close: 1},
+        { open: 2, high: 10, low: 0.5, close: 1},
+        { open: 1, high: 10, low: 0.5, close: 2},
+        { open: 4, high: 20, low: 2.9, close: 3},
+        { open: 1, high: 10, low: 0.5, close: 2},
+        { open: 3, high: 30, low: 1.4, close: 2},
       ];
 
-      const [r1, r2] = cs.shootingStar(data).map((e) => e.id);
-      assert.equal(1, r1);
-      assert.equal(5, r2);
+      const results = cs.shootingStar(data);
+      assert.deepStrictEqual([0, 4], results);
     });
   });
 });


### PR DESCRIPTION
Solves bug #12 . It comes with breaking changes, so please beware when upgrading to 0.0.6.


**=== :warning: BREAKING CHANGE WARNING ON VERSIONS <= 0.0.6 ===**

**Before:** search pattern functions returned the *last* OHLC object conforming the pattern.
**After:** they return the *first* **index** of the candle conforming the pattern. It helps 
locating candlestick in `dataArray` more easily. So before upgrading to version 0.0.6, please 
be aware of changing your code.