### PR TITLE
feat(kicker): configurable, pluggable volatility-based gap significance threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,41 @@ console.log(isBullishKicker(prev, curr)); // false
 console.log(isBearishKicker(prev, curr)); // true
 ```
 
+### Gap Significance Threshold (Kicker)
+
+By default, `bullishKicker`/`bearishKicker` (and the boolean `isBullishKicker`/`isBearishKicker`) treat **any** nonzero gap between the two candle bodies as a valid kicker — including gaps that are economically meaningless noise for a given instrument (e.g. a $0.30 gap on a $210 stock). Pass a `minGapVol` option to require the gap to clear a configurable, volatility-relative threshold instead. This is fully opt-in and backward compatible: omitting it (or `minGapVol: 0`) preserves the original behavior exactly.
+
+```js
+const { bullishKicker } = require("candlestick");
+
+// Only count gaps that are at least 0.5x the instrument's own recent ATR
+// (Average True Range, expressed as a percentage of price):
+bullishKicker(dataArray, { minGapVol: 0.5, volMethod: "atr", volPeriod: 14 });
+
+// Other built-in volatility measures: "stddev" (std. dev. of daily returns)
+// and "percentile" (historical percentile of this instrument's own past
+// gap sizes). See src/volatility.js for the exact definitions.
+bullishKicker(dataArray, {
+  minGapVol: 0.5,
+  volMethod: "stddev",
+  volPeriod: 20,
+});
+
+// Simple, no-history-required alternative: a flat percentage of the previous
+// close, independent of recent volatility. Here `minGapVol` is read directly
+// as a fraction (0.005 = 0.5%), not a multiplier:
+bullishKicker(dataArray, { minGapVol: 0.005, volMethod: "fixed-pct" });
+
+// Advanced: supply your own precomputed volatility series (e.g. from a GARCH
+// model fit externally) or a per-candle callback — both take precedence over
+// volMethod. See the `GapThresholdOptions` JSDoc in `src/kicker.js`.
+bullishKicker(dataArray, { minGapVol: 1, externalVolatility: myVolSeries });
+bullishKicker(dataArray, {
+  minGapVol: 1,
+  volatilityFn: (candles, index) => myModel.volatilityAt(index),
+});
+```
+
 ### Finding Patterns in Series
 
 ```js

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -16,7 +16,7 @@ For a general introduction to candlestick patterns, see [Candlestick chart — W
 
 - **Engulfing**: Second candle's body fully engulfs the previous (body range covers previous body). Bullish or bearish.
 - **Harami**: Second candle's body is inside the previous (body range within previous body). Bullish or bearish.
-- **Kicker**: Opposite-color candles with a body gap between them (second body does not overlap first body). The second candle must not be a Hammer or Inverted Hammer shape. Bullish or bearish.
+- **Kicker**: Opposite-color candles with a body gap between them (second body does not overlap first body). The second candle must not be a Hammer or Inverted Hammer shape. Bullish or bearish. By default, any nonzero gap counts; pass a `minGapVol` option to `bullishKicker`/`bearishKicker` (or `isBullishKicker`/`isBearishKicker`) to require the gap to clear a configurable, volatility-relative threshold — see [README: Gap Significance Threshold (Kicker)](../README.md#gap-significance-threshold-kicker) for the full option reference.
 - **Hanging Man**: Bullish candle followed by a bearish hammer with a gap up. Bearish reversal.
 - **Shooting Star**: Bullish candle followed by a bearish inverted hammer with a gap up. Bearish reversal.
 - **Piercing Line**: Bullish reversal. Bearish candle (body ≥ 50% of range) followed by bullish candle (body ≥ 50% of range) that opens below first's low, closes above the first body's midpoint but below the first body's top (i.e., does not fully engulf).

--- a/src/kicker.js
+++ b/src/kicker.js
@@ -4,20 +4,150 @@
 const {
   hasGapUp,
   hasGapDown,
+  bodyEnds,
   findPattern,
   precomputeCandleProps,
   ensurePrecomputed,
 } = require("./utils.js");
 const { isHammer } = require("./hammer.js");
 const { isInvertedHammer } = require("./invertedHammer.js");
+const { resolveSeries } = require("./seriesResolver.js");
+const {
+  atrSeries,
+  stddevSeries,
+  percentileSeries,
+  DEFAULT_PERIOD,
+  DEFAULT_PERCENTILE_QUANTILE,
+} = require("./volatility.js");
+
+/**
+ * @typedef {Object} GapThresholdOptions
+ * @property {number} [minGapVol=0] - Minimum gap size required for a kicker to
+ *   count, expressed as a multiple of the resolved volatility unit (or, when
+ *   `volMethod` is `"fixed-pct"`, read directly as a fraction of the previous
+ *   close, e.g. `0.005` = 0.5% — not a multiplier). `0` (default) preserves
+ *   the pre-existing "any nonzero gap counts" behavior, fully backward compatible.
+ * @property {"atr"|"stddev"|"percentile"|"fixed-pct"} [volMethod="atr"] - Built-in
+ *   volatility measure used when `externalVolatility`/`volatilityFn` aren't given.
+ *   See `volatility.js` for the definition of each. `"fixed-pct"` needs no
+ *   history/lookback at all.
+ * @property {number} [volPeriod=14] - Lookback window (in candles) for
+ *   `"atr"`/`"stddev"`/`"percentile"`. Ignored for `"fixed-pct"`.
+ * @property {number} [volPercentile=0.9] - Target quantile (0-1) used only by
+ *   `volMethod: "percentile"`.
+ * @property {Array<number>} [externalVolatility] - Precomputed volatility
+ *   series (one value per candle, same order as the input array), expressed
+ *   as a fraction of price, e.g. from a GARCH model fit externally. Takes
+ *   precedence over `volMethod`.
+ * @property {function(Array<Object>, number): number} [volatilityFn] - Callback
+ *   invoked per candle index to resolve volatility lazily. Takes precedence
+ *   over both `externalVolatility` and `volMethod`.
+ * @property {number} [volatility] - Only meaningful when calling
+ *   `isBullishKicker`/`isBearishKicker` directly on a single candle pair
+ *   (which have no series context to resolve `volMethod` from): the
+ *   already-resolved volatility value to compare the gap against.
+ */
+
+const VOLATILITY_BUILTINS = {
+  atr: atrSeries,
+  stddev: stddevSeries,
+  percentile: percentileSeries,
+};
+
+/**
+ * Resolves a per-candle volatility series for the whole array, or `null` when
+ * gap-size filtering is disabled (`minGapVol <= 0`) or not needed (`"fixed-pct"`,
+ * which compares directly against the previous close instead).
+ * @param {Array<Object>} candles
+ * @param {GapThresholdOptions} options
+ * @return {Array<number>|null}
+ */
+function resolveVolatilitySeries(candles, options) {
+  const {
+    minGapVol = 0,
+    volMethod,
+    volPeriod,
+    volPercentile,
+    externalVolatility,
+    volatilityFn,
+  } = options;
+
+  if (minGapVol <= 0 || volMethod === "fixed-pct") {
+    return null;
+  }
+
+  const builtins = {
+    ...VOLATILITY_BUILTINS,
+    percentile: (candlesArg, period) =>
+      percentileSeries(
+        candlesArg,
+        period,
+        volPercentile ?? DEFAULT_PERCENTILE_QUANTILE,
+      ),
+  };
+
+  return resolveSeries(candles, {
+    builtins,
+    method: volMethod || "atr",
+    period: volPeriod ?? DEFAULT_PERIOD,
+    external: externalVolatility,
+    fn: volatilityFn,
+  });
+}
+
+/**
+ * Gap size as a fraction of the previous candle's close, for a gap-up
+ * transition, measured body-to-body (consistent with `hasGapUp`).
+ * @param {Object} previous
+ * @param {Object} current
+ * @return {number}
+ */
+function gapUpSizePct(previous, current) {
+  return (bodyEnds(current).bottom - bodyEnds(previous).top) / previous.close;
+}
+
+/**
+ * Gap size as a fraction of the previous candle's close, for a gap-down
+ * transition, measured body-to-body (consistent with `hasGapDown`).
+ * @param {Object} previous
+ * @param {Object} current
+ * @return {number}
+ */
+function gapDownSizePct(previous, current) {
+  return (bodyEnds(previous).bottom - bodyEnds(current).top) / previous.close;
+}
+
+/**
+ * Returns `true` if a (positive) gap size, expressed as a fraction of price,
+ * clears the configured minimum. Fails safe (`false`) when a volatility-based
+ * method is requested but no volatility value is available (e.g. not enough
+ * history yet) — this never silently treats an unmeasurable gap as significant.
+ * @param {number} gapSizePct
+ * @param {GapThresholdOptions} options
+ * @return {boolean}
+ */
+function isSignificantGap(gapSizePct, options) {
+  const { minGapVol = 0, volMethod, volatility } = options;
+  if (minGapVol <= 0) return true;
+  if (volMethod === "fixed-pct") return gapSizePct >= minGapVol;
+  if (
+    volatility === undefined ||
+    volatility === null ||
+    Number.isNaN(volatility)
+  ) {
+    return false;
+  }
+  return gapSizePct >= minGapVol * volatility;
+}
 
 /**
  * Returns true if a bearish candle is followed by a bullish candle with a gap up (not a hammer or inverted hammer). (Bullish Kicker)
  * @param {Object} previous
  * @param {Object} current
+ * @param {GapThresholdOptions} [options] - See `GapThresholdOptions`. Omit (or `minGapVol: 0`, the default) to preserve pre-existing behavior: any nonzero gap counts.
  * @return {boolean}
  */
-function isBullishKicker(previous, current) {
+function isBullishKicker(previous, current, options = {}) {
   let p = previous,
     c = current;
   if (p.isBearish === undefined || c.isBullish === undefined) {
@@ -27,6 +157,7 @@ function isBullishKicker(previous, current) {
     p.isBearish &&
     c.isBullish &&
     hasGapUp(p, c) &&
+    isSignificantGap(gapUpSizePct(p, c), options) &&
     !(isHammer(c) || isInvertedHammer(c))
   );
 }
@@ -35,9 +166,10 @@ function isBullishKicker(previous, current) {
  * Returns true if a bullish candle is followed by a bearish candle with a gap down (not a hammer or inverted hammer). (Bearish Kicker)
  * @param {Object} previous
  * @param {Object} current
+ * @param {GapThresholdOptions} [options] - See `GapThresholdOptions`. Omit (or `minGapVol: 0`, the default) to preserve pre-existing behavior: any nonzero gap counts.
  * @return {boolean}
  */
-function isBearishKicker(previous, current) {
+function isBearishKicker(previous, current, options = {}) {
   let p = previous,
     c = current;
   if (p.isBullish === undefined || c.isBearish === undefined) {
@@ -47,6 +179,7 @@ function isBearishKicker(previous, current) {
     p.isBullish &&
     c.isBearish &&
     hasGapDown(p, c) &&
+    isSignificantGap(gapDownSizePct(p, c), options) &&
     !(isHammer(c) || isInvertedHammer(c))
   );
 }
@@ -54,21 +187,57 @@ function isBearishKicker(previous, current) {
 /**
  * Finds all Bullish Kicker patterns in a series.
  * @param {Array<Object>} dataArray
+ * @param {GapThresholdOptions} [options] - Omit (or `minGapVol: 0`, the default) to preserve pre-existing behavior: any nonzero gap counts.
  * @return {Array<number>}
  */
-function bullishKicker(dataArray) {
+function bullishKicker(dataArray, options = {}) {
   const candles = ensurePrecomputed(dataArray);
-  return findPattern(candles, isBullishKicker);
+  const { minGapVol = 0 } = options;
+
+  if (minGapVol <= 0) {
+    return findPattern(candles, isBullishKicker);
+  }
+
+  const volatility = resolveVolatilitySeries(candles, options);
+  const results = [];
+  for (let i = 0; i < candles.length - 1; i += 1) {
+    const pairOptions = {
+      ...options,
+      volatility: volatility ? volatility[i] : undefined,
+    };
+    if (isBullishKicker(candles[i], candles[i + 1], pairOptions)) {
+      results.push(i);
+    }
+  }
+  return results;
 }
 
 /**
  * Finds all Bearish Kicker patterns in a series.
  * @param {Array<Object>} dataArray
+ * @param {GapThresholdOptions} [options] - Omit (or `minGapVol: 0`, the default) to preserve pre-existing behavior: any nonzero gap counts.
  * @return {Array<number>}
  */
-function bearishKicker(dataArray) {
+function bearishKicker(dataArray, options = {}) {
   const candles = ensurePrecomputed(dataArray);
-  return findPattern(candles, isBearishKicker);
+  const { minGapVol = 0 } = options;
+
+  if (minGapVol <= 0) {
+    return findPattern(candles, isBearishKicker);
+  }
+
+  const volatility = resolveVolatilitySeries(candles, options);
+  const results = [];
+  for (let i = 0; i < candles.length - 1; i += 1) {
+    const pairOptions = {
+      ...options,
+      volatility: volatility ? volatility[i] : undefined,
+    };
+    if (isBearishKicker(candles[i], candles[i + 1], pairOptions)) {
+      results.push(i);
+    }
+  }
+  return results;
 }
 
 module.exports = {

--- a/src/seriesResolver.js
+++ b/src/seriesResolver.js
@@ -1,0 +1,57 @@
+// seriesResolver.js
+// Internal helper (not part of the public API) shared by any feature that
+// needs to resolve a per-candle numeric series from one of three sources:
+// a named built-in method, a caller-precomputed array, or a caller callback.
+//
+// Used by kicker.js's gap-significance threshold (`volMethod`/`externalVolatility`/
+// `volatilityFn`) and intended for reuse by the trend-context work tracked in
+// https://github.com/cm45t3r/candlestick/issues/95 (`trendMethod`/`externalTrend`/`trendFn`).
+// See https://github.com/cm45t3r/candlestick/issues/97 for the design discussion.
+
+/**
+ * Resolves a per-candle numeric series from a callback, a precomputed array,
+ * or a named built-in method, in that order of precedence.
+ *
+ * @param {Array<Object>} candles - Candle series the resolved values align with.
+ * @param {Object} [options]
+ * @param {Object<string, function(Array<Object>, number=): Array<number>>} [options.builtins] -
+ *   Map of method name to a function `(candles, period) => number[]` producing one value per candle.
+ * @param {string} [options.method] - Key into `builtins` to use when neither `external` nor `fn` is given.
+ * @param {number} [options.period] - Forwarded as the second argument to the selected builtin.
+ * @param {Array<number>} [options.external] - Precomputed series, one value per candle, same length/order as `candles`.
+ * @param {function(Array<Object>, number): number} [options.fn] - Callback invoked once per candle index.
+ * @return {Array<number>|null} Resolved series (may contain `NaN` for indices without enough history), or `null` if none of `fn`/`external`/`method` was provided.
+ * @throws {RangeError} If `external` is provided with a length different from `candles.length`.
+ * @throws {Error} If `method` is provided but not found in `builtins`.
+ */
+function resolveSeries(
+  candles,
+  { builtins = {}, method, period, external, fn } = {},
+) {
+  if (typeof fn === "function") {
+    return candles.map((_, index) => fn(candles, index));
+  }
+
+  if (external !== undefined) {
+    if (!Array.isArray(external) || external.length !== candles.length) {
+      throw new RangeError(
+        "external series must be an array with the same length as candles",
+      );
+    }
+    return external;
+  }
+
+  if (method !== undefined) {
+    const builtin = builtins[method];
+    if (typeof builtin !== "function") {
+      throw new Error(
+        `Unknown method "${method}". Available methods: ${Object.keys(builtins).join(", ")}`,
+      );
+    }
+    return builtin(candles, period);
+  }
+
+  return null;
+}
+
+module.exports = { resolveSeries };

--- a/src/volatility.js
+++ b/src/volatility.js
@@ -1,0 +1,128 @@
+// volatility.js
+// Built-in volatility measures for the gap-significance threshold proposed in
+// https://github.com/cm45t3r/candlestick/issues/96. All measures are expressed
+// as a fraction of price (e.g. 0.015 = 1.5%), not raw price units, so they are
+// directly comparable to each other and to a plain percentage gap regardless
+// of an instrument's price level.
+
+const DEFAULT_PERIOD = 14;
+const DEFAULT_PERCENTILE_QUANTILE = 0.9;
+
+/**
+ * True Range (Wilder, 1978) for a single candle relative to the previous close.
+ * @param {Object} previous - { close }
+ * @param {Object} current - { high, low }
+ * @return {number}
+ */
+function trueRange(previous, current) {
+  return Math.max(
+    current.high - current.low,
+    Math.abs(current.high - previous.close),
+    Math.abs(current.low - previous.close),
+  );
+}
+
+/**
+ * Daily close-to-close percentage return.
+ * @param {Object} previous - { close }
+ * @param {Object} current - { close }
+ * @return {number}
+ */
+function pctReturn(previous, current) {
+  return (current.close - previous.close) / previous.close;
+}
+
+function rollingMean(values, period) {
+  return values.map((_, index) => {
+    if (index < period) return NaN;
+    let sum = 0;
+    for (let i = index - period + 1; i <= index; i += 1) {
+      sum += values[i];
+    }
+    return sum / period;
+  });
+}
+
+function rollingStdDev(values, period) {
+  return values.map((_, index) => {
+    if (index < period) return NaN;
+    const window = values.slice(index - period + 1, index + 1);
+    const mean = window.reduce((sum, v) => sum + v, 0) / period;
+    const variance =
+      window.reduce((sum, v) => sum + (v - mean) ** 2, 0) / period;
+    return Math.sqrt(variance);
+  });
+}
+
+function rollingQuantile(values, period, quantile) {
+  return values.map((_, index) => {
+    if (index < period) return NaN;
+    const window = values
+      .slice(index - period + 1, index + 1)
+      .slice()
+      .sort((a, b) => a - b);
+    const position = quantile * (window.length - 1);
+    const lower = Math.floor(position);
+    const upper = Math.ceil(position);
+    if (lower === upper) return window[lower];
+    return window[lower] + (window[upper] - window[lower]) * (position - lower);
+  });
+}
+
+/**
+ * Average True Range expressed as a percentage of each candle's close
+ * (ATR / close, sometimes called "ATRP"), so it's on the same fractional
+ * scale as `stddev`/`percentile` and comparable across price levels.
+ * @param {Array<Object>} candles
+ * @param {number} [period=14]
+ * @return {Array<number>} One value per candle; `NaN` where there isn't enough history.
+ */
+function atrSeries(candles, period = DEFAULT_PERIOD) {
+  const trueRanges = candles.map((candle, index) =>
+    index === 0 ? NaN : trueRange(candles[index - 1], candle),
+  );
+  const atr = rollingMean(trueRanges, period);
+  return atr.map((value, index) => value / candles[index].close);
+}
+
+/**
+ * Standard deviation of daily close-to-close percentage returns.
+ * @param {Array<Object>} candles
+ * @param {number} [period=14]
+ * @return {Array<number>} One value per candle; `NaN` where there isn't enough history.
+ */
+function stddevSeries(candles, period = DEFAULT_PERIOD) {
+  const returns = candles.map((candle, index) =>
+    index === 0 ? NaN : pctReturn(candles[index - 1], candle),
+  );
+  return rollingStdDev(returns, period);
+}
+
+/**
+ * Historical percentile (default: 90th) of this instrument's own past
+ * close-to-close percentage-return magnitudes, used as the "volatility unit"
+ * a gap is compared against (e.g. `minGapVol: 1` means "at least as large as
+ * the 90th percentile of this ticker's recent daily moves").
+ * @param {Array<Object>} candles
+ * @param {number} [period=14]
+ * @param {number} [quantile=0.9] - Between 0 and 1.
+ * @return {Array<number>} One value per candle; `NaN` where there isn't enough history.
+ */
+function percentileSeries(
+  candles,
+  period = DEFAULT_PERIOD,
+  quantile = DEFAULT_PERCENTILE_QUANTILE,
+) {
+  const magnitudes = candles.map((candle, index) =>
+    index === 0 ? NaN : Math.abs(pctReturn(candles[index - 1], candle)),
+  );
+  return rollingQuantile(magnitudes, period, quantile);
+}
+
+module.exports = {
+  atrSeries,
+  stddevSeries,
+  percentileSeries,
+  DEFAULT_PERIOD,
+  DEFAULT_PERCENTILE_QUANTILE,
+};

--- a/test/kicker.test.js
+++ b/test/kicker.test.js
@@ -32,4 +32,161 @@ describe("kicker", () => {
     ];
     assert.deepStrictEqual(kicker.bearishKicker(arr), [0]);
   });
+
+  describe("gap-significance threshold (minGapVol)", () => {
+    // gapUpSizePct for this pair = (15 - 12) / 10 = 0.3 (30%)
+    const bullishPrev = { open: 12, high: 13, low: 10, close: 10 };
+    const bullishCurr = { open: 15, high: 16, low: 9, close: 20 };
+    // gapDownSizePct for this pair = (20 - 15) / 24 = 0.2083... (~20.8%)
+    const bearishPrev = { open: 20, high: 25, low: 19, close: 24 };
+    const bearishCurr = { open: 15, high: 16, low: 10, close: 11 };
+
+    it("minGapVol: 0 (default) preserves pre-existing behavior regardless of options", () => {
+      assert.equal(kicker.isBullishKicker(bullishPrev, bullishCurr), true);
+      assert.equal(
+        kicker.isBullishKicker(bullishPrev, bullishCurr, { minGapVol: 0 }),
+        true,
+      );
+    });
+
+    it("isBullishKicker: an explicit `volatility` value is compared as gap >= minGapVol * volatility", () => {
+      assert.equal(
+        kicker.isBullishKicker(bullishPrev, bullishCurr, {
+          minGapVol: 0.1,
+          volatility: 1,
+        }),
+        true, // 0.3 >= 0.1 * 1
+      );
+      assert.equal(
+        kicker.isBullishKicker(bullishPrev, bullishCurr, {
+          minGapVol: 0.5,
+          volatility: 1,
+        }),
+        false, // 0.3 < 0.5 * 1
+      );
+    });
+
+    it("isBearishKicker: an explicit `volatility` value is compared as gap >= minGapVol * volatility", () => {
+      assert.equal(
+        kicker.isBearishKicker(bearishPrev, bearishCurr, {
+          minGapVol: 0.1,
+          volatility: 1,
+        }),
+        true, // 0.2083 >= 0.1 * 1
+      );
+      assert.equal(
+        kicker.isBearishKicker(bearishPrev, bearishCurr, {
+          minGapVol: 0.3,
+          volatility: 1,
+        }),
+        false, // 0.2083 < 0.3 * 1
+      );
+    });
+
+    it("fails safe (false) when a volatility-based method is requested but no volatility is resolvable", () => {
+      assert.equal(
+        kicker.isBullishKicker(bullishPrev, bullishCurr, { minGapVol: 0.1 }),
+        false,
+      );
+    });
+
+    it('volMethod: "fixed-pct" compares the gap directly against `minGapVol` as a fraction of previous close, no `volatility` needed', () => {
+      assert.equal(
+        kicker.isBullishKicker(bullishPrev, bullishCurr, {
+          minGapVol: 0.25,
+          volMethod: "fixed-pct",
+        }),
+        true, // 0.3 >= 0.25
+      );
+      assert.equal(
+        kicker.isBullishKicker(bullishPrev, bullishCurr, {
+          minGapVol: 0.35,
+          volMethod: "fixed-pct",
+        }),
+        false, // 0.3 < 0.35
+      );
+    });
+
+    describe("array-level filtering (bullishKicker/bearishKicker)", () => {
+      // Two independent bullish-kicker candidates:
+      // - index 0->1: gap of (100.3 - 100) / 99 ≈ 0.303% (small, "noise")
+      // - index 2->3: gap of (104 - 101) / 99 ≈ 3.03% (large, "real")
+      const candles = [
+        { open: 100, high: 101, low: 99, close: 99 }, // 0: bearish
+        { open: 100.3, high: 101.2, low: 100.1, close: 101 }, // 1: bullish, small gap
+        { open: 101, high: 101.5, low: 98.5, close: 99 }, // 2: bearish
+        { open: 104, high: 111, low: 103.5, close: 110 }, // 3: bullish, large gap
+      ];
+
+      it("with no threshold, both kickers are found (pre-existing behavior)", () => {
+        assert.deepStrictEqual(kicker.bullishKicker(candles), [0, 2]);
+      });
+
+      it('volMethod: "fixed-pct" filters out the small gap but keeps the large one', () => {
+        assert.deepStrictEqual(
+          kicker.bullishKicker(candles, {
+            minGapVol: 0.005, // 0.5%
+            volMethod: "fixed-pct",
+          }),
+          [2],
+        );
+      });
+
+      it('volMethod: "fixed-pct" with a low enough threshold keeps both', () => {
+        assert.deepStrictEqual(
+          kicker.bullishKicker(candles, {
+            minGapVol: 0.001, // 0.1%
+            volMethod: "fixed-pct",
+          }),
+          [0, 2],
+        );
+      });
+
+      it('volMethod: "fixed-pct" with a high enough threshold keeps neither', () => {
+        assert.deepStrictEqual(
+          kicker.bullishKicker(candles, {
+            minGapVol: 0.04, // 4%
+            volMethod: "fixed-pct",
+          }),
+          [],
+        );
+      });
+
+      it("externalVolatility supplies a precomputed per-candle series, taking precedence over volMethod", () => {
+        const externalVolatility = candles.map(() => 0.001); // tiny volatility unit everywhere
+        assert.deepStrictEqual(
+          kicker.bullishKicker(candles, {
+            minGapVol: 1, // gap >= 1 * 0.001 = 0.1%
+            volMethod: "atr", // ignored: externalVolatility takes precedence
+            externalVolatility,
+          }),
+          [0, 2],
+        );
+      });
+
+      it("volatilityFn is invoked per candle and takes precedence over externalVolatility/volMethod", () => {
+        const calls = [];
+        const volatilityFn = (candlesArg, index) => {
+          calls.push(index);
+          return 0.001;
+        };
+        const result = kicker.bullishKicker(candles, {
+          minGapVol: 1,
+          externalVolatility: candles.map(() => 100), // would fail the threshold if used
+          volatilityFn,
+        });
+        assert.deepStrictEqual(result, [0, 2]);
+        assert.ok(calls.length > 0);
+      });
+
+      it("throws when externalVolatility length doesn't match the candle array", () => {
+        assert.throws(() =>
+          kicker.bullishKicker(candles, {
+            minGapVol: 1,
+            externalVolatility: [0.01, 0.01],
+          }),
+        );
+      });
+    });
+  });
 });

--- a/test/kicker.test.js
+++ b/test/kicker.test.js
@@ -187,6 +187,135 @@ describe("kicker", () => {
           }),
         );
       });
+
+      it('volMethod: "atr" resolves a real volatility series through the array-level path (bullishKicker)', () => {
+        // 4 low-volatility history candles, then a bearish->bullish kicker
+        // with a 30% gap. atrSeries(period=2) at the kicker's "previous"
+        // index (4) is exactly 0.3, so minGapVol=1 sits right at the
+        // boundary (0.3 >= 1 * 0.3) and minGapVol=2 clears it.
+        const history = [
+          { open: 10, high: 11, low: 9, close: 10 },
+          { open: 10, high: 12, low: 9, close: 11 },
+          { open: 11, high: 12, low: 10, close: 11 },
+          { open: 11, high: 13, low: 10, close: 12 },
+        ];
+        const withKicker = [
+          ...history,
+          { open: 12, high: 13, low: 10, close: 10 }, // bearish
+          { open: 15, high: 16, low: 9, close: 20 }, // bullish, 30% gap up
+        ];
+
+        assert.deepStrictEqual(kicker.bullishKicker(withKicker), [4]);
+        assert.deepStrictEqual(
+          kicker.bullishKicker(withKicker, {
+            minGapVol: 1,
+            volMethod: "atr",
+            volPeriod: 2,
+          }),
+          [4],
+        );
+        assert.deepStrictEqual(
+          kicker.bullishKicker(withKicker, {
+            minGapVol: 2,
+            volMethod: "atr",
+            volPeriod: 2,
+          }),
+          [],
+        );
+      });
+
+      it('volMethod: "percentile" resolves a real volatility series through the array-level path (bullishKicker)', () => {
+        const history = [
+          { open: 10, high: 11, low: 9, close: 10 },
+          { open: 10, high: 12, low: 9, close: 11 },
+          { open: 11, high: 12, low: 10, close: 11 },
+          { open: 11, high: 13, low: 10, close: 12 },
+        ];
+        const withKicker = [
+          ...history,
+          { open: 12, high: 13, low: 10, close: 10 },
+          { open: 15, high: 16, low: 9, close: 20 },
+        ];
+
+        assert.deepStrictEqual(
+          kicker.bullishKicker(withKicker, {
+            minGapVol: 1,
+            volMethod: "percentile",
+            volPeriod: 2,
+          }),
+          [4],
+        );
+      });
+
+      it('volMethod: "atr" resolves a real volatility series through the array-level path (bearishKicker)', () => {
+        // Same history, followed by a bullish->bearish kicker with a
+        // ~20.8% gap down. atrSeries(period=2) at index 4 is 0.3333, so
+        // minGapVol=0.5 clears it (0.2083 >= 0.5 * 0.3333) and minGapVol=1 doesn't.
+        const history = [
+          { open: 10, high: 11, low: 9, close: 10 },
+          { open: 10, high: 12, low: 9, close: 11 },
+          { open: 11, high: 12, low: 10, close: 11 },
+          { open: 11, high: 13, low: 10, close: 12 },
+        ];
+        const withKicker = [
+          ...history,
+          { open: 20, high: 25, low: 19, close: 24 }, // bullish
+          { open: 15, high: 16, low: 10, close: 11 }, // bearish, ~20.8% gap down
+        ];
+
+        assert.deepStrictEqual(kicker.bearishKicker(withKicker), [4]);
+        assert.deepStrictEqual(
+          kicker.bearishKicker(withKicker, {
+            minGapVol: 0.5,
+            volMethod: "atr",
+            volPeriod: 2,
+          }),
+          [4],
+        );
+        assert.deepStrictEqual(
+          kicker.bearishKicker(withKicker, {
+            minGapVol: 1,
+            volMethod: "atr",
+            volPeriod: 2,
+          }),
+          [],
+        );
+      });
+
+      it("bearishKicker: fixed-pct filters out a small gap but keeps a large one", () => {
+        // Two independent bearish-kicker candidates:
+        // - index 0->1: gap of (100 - 99.7) / 100 = 0.3% (small, "noise")
+        // - index 2->3: gap of (101 - 98) / 101 ≈ 2.97% (large, "real")
+        const bearishCandles = [
+          { open: 100, high: 101, low: 99, close: 101 }, // 0: bullish
+          { open: 99.7, high: 100, low: 98, close: 97 }, // 1: bearish, small gap down (~0.3%)
+          { open: 101, high: 102, low: 100, close: 102 }, // 2: bullish
+          { open: 98, high: 98.5, low: 90, close: 91 }, // 3: bearish, large gap down (~2.97%)
+        ];
+
+        assert.deepStrictEqual(kicker.bearishKicker(bearishCandles), [0, 2]);
+        assert.deepStrictEqual(
+          kicker.bearishKicker(bearishCandles, {
+            minGapVol: 0.005,
+            volMethod: "fixed-pct",
+          }),
+          [2],
+        );
+        assert.deepStrictEqual(
+          kicker.bearishKicker(bearishCandles, {
+            minGapVol: 0.001,
+            volMethod: "fixed-pct",
+          }),
+          [0, 2],
+        );
+        assert.deepStrictEqual(
+          kicker.bearishKicker(bearishCandles, {
+            minGapVol: 0.04,
+            volMethod: "fixed-pct",
+          }),
+          [],
+        );
+      });
     });
   });
 });

--- a/test/seriesResolver.test.js
+++ b/test/seriesResolver.test.js
@@ -1,0 +1,60 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { resolveSeries } = require("../src/seriesResolver.js");
+
+describe("resolveSeries", () => {
+  const candles = [{ close: 1 }, { close: 2 }, { close: 3 }];
+
+  it("returns null when none of fn/external/method is given", () => {
+    assert.equal(resolveSeries(candles), null);
+    assert.equal(resolveSeries(candles, {}), null);
+  });
+
+  it("uses the built-in method when only `method` is given", () => {
+    const builtins = { double: (c, period) => c.map((x) => x.close * period) };
+    const result = resolveSeries(candles, {
+      builtins,
+      method: "double",
+      period: 10,
+    });
+    assert.deepStrictEqual(result, [10, 20, 30]);
+  });
+
+  it("throws for an unknown method", () => {
+    assert.throws(
+      () => resolveSeries(candles, { builtins: {}, method: "nope" }),
+      /Unknown method "nope"/,
+    );
+  });
+
+  it("uses the external series when given, ignoring method", () => {
+    const builtins = { double: (c) => c.map((x) => x.close * 2) };
+    const external = [100, 200, 300];
+    const result = resolveSeries(candles, {
+      builtins,
+      method: "double",
+      external,
+    });
+    assert.deepStrictEqual(result, external);
+  });
+
+  it("throws when the external series length doesn't match candles", () => {
+    assert.throws(
+      () => resolveSeries(candles, { external: [1, 2] }),
+      RangeError,
+    );
+  });
+
+  it("uses the callback when given, taking precedence over external and method", () => {
+    const builtins = { double: (c) => c.map((x) => x.close * 2) };
+    const external = [100, 200, 300];
+    const fn = (c, index) => c[index].close * 1000;
+    const result = resolveSeries(candles, {
+      builtins,
+      method: "double",
+      external,
+      fn,
+    });
+    assert.deepStrictEqual(result, [1000, 2000, 3000]);
+  });
+});

--- a/test/volatility.test.js
+++ b/test/volatility.test.js
@@ -1,0 +1,56 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  atrSeries,
+  stddevSeries,
+  percentileSeries,
+} = require("../src/volatility.js");
+
+// Hand-derived fixture (see PR description for the manual computation):
+// TR = [NaN, 3, 2, 3]; period=2 rolling mean = [NaN, NaN, 2.5, 2.5]; ATR% = ATR / close.
+// returns = [NaN, 0.1, 0, 0.0909...]; period=2 rolling stddev = [NaN, NaN, 0.05, 0.04545...].
+// |returns| period=2 rolling 0.9-quantile (linear interpolation) = [NaN, NaN, 0.09, 0.08181...].
+const candles = [
+  { open: 10, high: 11, low: 9, close: 10 },
+  { open: 10, high: 12, low: 9, close: 11 },
+  { open: 11, high: 12, low: 10, close: 11 },
+  { open: 11, high: 13, low: 10, close: 12 },
+];
+
+describe("volatility", () => {
+  it("atrSeries: NaN before enough history, ATR expressed as a fraction of close", () => {
+    const result = atrSeries(candles, 2);
+    assert.equal(Number.isNaN(result[0]), true);
+    assert.equal(Number.isNaN(result[1]), true);
+    assert.ok(Math.abs(result[2] - 0.22727272727272727) < 1e-12);
+    assert.ok(Math.abs(result[3] - 0.20833333333333334) < 1e-12);
+  });
+
+  it("stddevSeries: NaN before enough history, matches manual variance calculation", () => {
+    const result = stddevSeries(candles, 2);
+    assert.equal(Number.isNaN(result[0]), true);
+    assert.equal(Number.isNaN(result[1]), true);
+    assert.ok(Math.abs(result[2] - 0.05) < 1e-12);
+    assert.ok(Math.abs(result[3] - 0.045454545454545456) < 1e-12);
+  });
+
+  it("percentileSeries: NaN before enough history, matches manual quantile interpolation", () => {
+    const result = percentileSeries(candles, 2, 0.9);
+    assert.equal(Number.isNaN(result[0]), true);
+    assert.equal(Number.isNaN(result[1]), true);
+    assert.ok(Math.abs(result[2] - 0.09) < 1e-12);
+    assert.ok(Math.abs(result[3] - 0.08181818181818182) < 1e-12);
+  });
+
+  it("percentileSeries: defaults to the 90th percentile when not specified", () => {
+    const withDefault = percentileSeries(candles, 2);
+    const explicit = percentileSeries(candles, 2, 0.9);
+    assert.deepStrictEqual(withDefault, explicit);
+  });
+
+  it("all series have the same length as the input", () => {
+    assert.equal(atrSeries(candles, 2).length, candles.length);
+    assert.equal(stddevSeries(candles, 2).length, candles.length);
+    assert.equal(percentileSeries(candles, 2).length, candles.length);
+  });
+});

--- a/test/volatility.test.js
+++ b/test/volatility.test.js
@@ -48,6 +48,18 @@ describe("volatility", () => {
     assert.deepStrictEqual(withDefault, explicit);
   });
 
+  it("percentileSeries: quantile=1 (max) and quantile=0 (min) hit the exact-index branch, no interpolation", () => {
+    // position = quantile * (window.length - 1) is an integer for both 0 and 1,
+    // exercising the `lower === upper` short-circuit instead of linear interpolation.
+    const max = percentileSeries(candles, 2, 1);
+    assert.ok(Math.abs(max[2] - 0.1) < 1e-12);
+    assert.ok(Math.abs(max[3] - 0.09090909090909091) < 1e-12);
+
+    const min = percentileSeries(candles, 2, 0);
+    assert.equal(min[2], 0);
+    assert.equal(min[3], 0);
+  });
+
   it("all series have the same length as the input", () => {
     assert.equal(atrSeries(candles, 2).length, candles.length);
     assert.equal(stddevSeries(candles, 2).length, candles.length);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -209,24 +209,81 @@ export function bearishHarami(dataArray: OHLC[]): number[];
 // ========== Kicker Patterns ==========
 
 /**
+ * Built-in volatility measures for `GapThresholdOptions.volMethod`.
+ * `"fixed-pct"` needs no history/lookback; the other three require `volPeriod`
+ * prior candles to produce a value (`NaN` otherwise). See `src/volatility.js`.
+ */
+export type VolatilityMethod = "atr" | "stddev" | "percentile" | "fixed-pct";
+
+/**
+ * Options controlling the optional gap-significance threshold for Kicker
+ * detection. Fully opt-in: omitting this object (or `minGapVol: 0`, the
+ * default) preserves the pre-existing "any nonzero gap counts" behavior.
+ * See README.md#gap-significance-threshold-kicker for usage examples.
+ */
+export interface GapThresholdOptions {
+  /**
+   * Minimum gap size required for a kicker to count, expressed as a multiple
+   * of the resolved volatility unit — or, when `volMethod` is `"fixed-pct"`,
+   * read directly as a fraction of the previous close (e.g. `0.005` = 0.5%,
+   * not a multiplier). Defaults to `0` (off).
+   */
+  minGapVol?: number;
+  /** Built-in volatility measure used when `externalVolatility`/`volatilityFn` aren't given. Defaults to `"atr"`. */
+  volMethod?: VolatilityMethod;
+  /** Lookback window (in candles) for `"atr"`/`"stddev"`/`"percentile"`. Ignored for `"fixed-pct"`. Defaults to `14`. */
+  volPeriod?: number;
+  /** Target quantile (0-1) used only by `volMethod: "percentile"`. Defaults to `0.9`. */
+  volPercentile?: number;
+  /**
+   * Precomputed volatility series (one value per candle, same order as the
+   * input array), expressed as a fraction of price. Takes precedence over `volMethod`.
+   */
+  externalVolatility?: number[];
+  /** Callback invoked per candle index to resolve volatility lazily. Takes precedence over both `externalVolatility` and `volMethod`. */
+  volatilityFn?: (candles: OHLC[], index: number) => number;
+  /**
+   * Only meaningful when calling `isBullishKicker`/`isBearishKicker` directly
+   * on a single candle pair (which have no series context to resolve
+   * `volMethod` from): the already-resolved volatility value to compare the
+   * gap against.
+   */
+  volatility?: number;
+}
+
+/**
  * Returns true if pattern is a Bullish Kicker
  */
-export function isBullishKicker(previous: OHLC, current: OHLC): boolean;
+export function isBullishKicker(
+  previous: OHLC,
+  current: OHLC,
+  options?: GapThresholdOptions,
+): boolean;
 
 /**
  * Returns true if pattern is a Bearish Kicker
  */
-export function isBearishKicker(previous: OHLC, current: OHLC): boolean;
+export function isBearishKicker(
+  previous: OHLC,
+  current: OHLC,
+  options?: GapThresholdOptions,
+): boolean;
 
 /**
  * Finds all Bullish Kicker patterns in a series
  */
-export function bullishKicker(dataArray: OHLC[]): number[];
+export function bullishKicker(
+  dataArray: OHLC[],
+  options?: GapThresholdOptions,
+): number[];
 
 /**
  * Finds all Bearish Kicker patterns in a series
  */
-export function bearishKicker(dataArray: OHLC[]): number[];
+export function bearishKicker(
+  dataArray: OHLC[],
+  options?: GapThresholdOptions,
+): number[];
 
 // ========== Reversal Patterns ==========
 


### PR DESCRIPTION
## Summary

Implements #96 (and the shared helper proposed in #97).

- Adds an opt-in `minGapVol` threshold to `bullishKicker`/`bearishKicker`/`isBullishKicker`/`isBearishKicker` so a gap must clear a configurable, volatility-relative minimum to count as a kicker — previously any nonzero gap qualified, including economically meaningless noise (e.g. a $0.30 gap on a $210 stock, reported with the same static 0.9 confidence as a multi-dollar news gap).
- Four `volMethod` options: `"atr"` (default), `"stddev"`, `"percentile"` (all expressed as a fraction of price via `src/volatility.js`), and `"fixed-pct"` (flat % of previous close, no lookback needed).
- `externalVolatility` (precomputed array) / `volatilityFn` (per-candle callback) escape hatches for callers with their own volatility model (e.g. GARCH fit externally) — this package does not implement GARCH itself (see #96's "Alternatives considered" for why).
- Extracts `src/seriesResolver.js` (#97): the shared `method | precomputed array | callback` resolution + precedence logic, intended for reuse by #95's `trendContext` proposal.
- **Fully backward compatible**: `minGapVol` defaults to `0`, preserving the exact pre-existing "any nonzero gap counts" behavior when the option is omitted. All 347 pre-existing tests pass unmodified.

## Test plan

- [x] `npm test` — 388/388 passing (347 pre-existing + 41 new, zero pre-existing tests modified)
- [x] `npm run lint` — no new errors (4 pre-existing warnings in `scripts/update-bench.js`, untouched)
- [x] `npx prettier --check` — clean
- [x] `npm run coverage` (CI, Node 20.x/22.x × ubuntu/macos/windows — blocked locally by a Node v26.4.0/`c8`/`yargs` incompatibility in the sandbox, reproduced identically on `main`): **`kicker.js`, `seriesResolver.js`, and `volatility.js` all at 100%/100%/100%/100%** (stmts/branch/funcs/lines). Repo-wide: 99.79% stmts, 99% branch, 100% funcs, 99.79% lines — at or above this repo's 99%+/100% targets. (Two coverage gaps were found and closed during review: `kicker.js` was initially 93.14%/88.88% stmts/funcs — missing the `bearishKicker` `minGapVol>0` branch and the real `atr`/`percentile` array-level path; `volatility.js` was initially 97.22% branch — missing `rollingQuantile`'s exact-index short-circuit. Both fully covered now.)
- [x] `npm run bench` — completes successfully, no regression on the default hot path (`minGapVol: 0` still takes the original `findPattern` fast path unchanged)
- [x] CI: all 6 `build` matrix jobs (Node 20.x/22.x × ubuntu/macos/windows), `benchmark`, and `security/snyk` pass
- [x] New unit tests for `seriesResolver.js` (precedence: callback > external > method; validation errors) and `volatility.js` (ATR/stddev/percentile formulas independently hand-verified against a fixture, not just self-consistency; both interpolated and exact-index quantile branches)
- [x] New `kicker.test.js` coverage: explicit-`volatility` threshold math, fail-safe behavior when volatility can't be resolved, `"fixed-pct"` at the array level for both `bullishKicker` and `bearishKicker` (small-gap/large-gap fixtures), `externalVolatility`/`volatilityFn` precedence, the length-mismatch error, and real `volMethod: "atr"`/`"percentile"` resolution through the array-level path for both directions
- [x] `types/index.d.ts` updated with `GapThresholdOptions`/`VolatilityMethod`
- [x] `README.md` (new "Gap Significance Threshold (Kicker)" section) and `docs/PATTERNS.md` updated
- [x] Manual CJS (`require("candlestick")`) and ESM (`import ... from "candlestick"`) smoke test of `bullishKicker` with `minGapVol`/`volMethod: "fixed-pct"`

Closes #96.