### PR TITLE
feat(patternChain): trend-context-aware confidence, deprecate static confidence

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -73,8 +73,7 @@ jobs:
           CURRENT_SHA="${{ github.event.pull_request.head.sha }}"
 
           HAD_ALERT_THIS_RUN=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq --arg sha "$CURRENT_SHA" \
-            '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Alert -->")) | select(.body | contains("Current: " + $sha))] | length > 0')
+            --jq "[.[] | select(.body | startswith(\"<!-- github-benchmark-action-comment(start): Benchmark Alert -->\")) | select(.body | contains(\"Current: $CURRENT_SHA\"))] | length > 0")
 
           MARKER="<!-- benchmark-status-comment -->"
           if [ "$HAD_ALERT_THIS_RUN" = "true" ]; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -62,3 +62,27 @@ jobs:
           fail-on-alert: false
           alert-comment-cc-users: "@cm45t3r"
           benchmark-data-dir-path: dev/bench
+
+      - name: Add friendly header to benchmark summary comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Summary -->"))][-1].id // empty')
+          if [ -z "$REVIEW_ID" ]; then
+            echo "No summary comment found yet, skipping"
+            exit 0
+          fi
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.body' > /tmp/summary_body.md
+          awk '
+            1
+            /^# Benchmark$/ && !done {
+              print ""
+              print ":white_check_mark: **Good job — no unexpected performance regressions in this run.**"
+              done = 1
+            }
+          ' /tmp/summary_body.md > /tmp/summary_body_new.md
+          gh api -X PATCH "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" -f body=@/tmp/summary_body_new.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,6 +58,7 @@ jobs:
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           alert-threshold: "150%"
           comment-on-alert: true
+          comment-always: true
           fail-on-alert: false
           alert-comment-cc-users: "@cm45t3r"
           benchmark-data-dir-path: dev/bench

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,18 +75,24 @@ jobs:
           HAD_ALERT_THIS_RUN=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
             --jq "[.[] | select(.body | startswith(\"<!-- github-benchmark-action-comment(start): Benchmark Alert -->\")) | select(.body | contains(\"Current: $CURRENT_SHA\"))] | length > 0")
 
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Summary -->"))][-1].body // empty' \
+            | sed '/^<!-- github-benchmark-action-comment/d' > /tmp/table.md
+
           MARKER="<!-- benchmark-status-comment -->"
           if [ "$HAD_ALERT_THIS_RUN" = "true" ]; then
             {
               echo "$MARKER"
               echo ":warning: **Performance regression detected in this run** — see the Alert comment above for details."
+              echo ""
+              cat /tmp/table.md
             } > /tmp/status_body.md
           else
             {
               echo "$MARKER"
               echo ":white_check_mark: **Good job — no unexpected performance regressions in this run.**"
               echo ""
-              echo "See the detailed comparison table below."
+              cat /tmp/table.md
             } > /tmp/status_body.md
           fi
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,40 +63,39 @@ jobs:
           alert-comment-cc-users: "@cm45t3r"
           benchmark-data-dir-path: dev/bench
 
-      - name: Add friendly header to benchmark summary comment
+      - name: Add friendly benchmark status comment
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          echo "::group::list reviews"
-          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" > /tmp/reviews.json
-          echo "list reviews OK"
-          echo "::endgroup::"
+          CURRENT_SHA="${{ github.event.pull_request.head.sha }}"
 
-          REVIEW_ID=$(jq -r '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Summary -->"))][-1].id // empty' /tmp/reviews.json)
-          echo "REVIEW_ID=$REVIEW_ID"
-          if [ -z "$REVIEW_ID" ]; then
-            echo "No summary comment found yet, skipping"
-            exit 0
+          HAD_ALERT_THIS_RUN=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq --arg sha "$CURRENT_SHA" \
+            '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Alert -->")) | select(.body | contains("Current: " + $sha))] | length > 0')
+
+          MARKER="<!-- benchmark-status-comment -->"
+          if [ "$HAD_ALERT_THIS_RUN" = "true" ]; then
+            {
+              echo "$MARKER"
+              echo ":warning: **Performance regression detected in this run** — see the Alert comment above for details."
+            } > /tmp/status_body.md
+          else
+            {
+              echo "$MARKER"
+              echo ":white_check_mark: **Good job — no unexpected performance regressions in this run.**"
+              echo ""
+              echo "See the detailed comparison table below."
+            } > /tmp/status_body.md
           fi
 
-          echo "::group::get review body"
-          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.body' > /tmp/summary_body.md
-          echo "get review body OK"
-          echo "::endgroup::"
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- benchmark-status-comment -->"))][-1].id // empty')
 
-          awk '
-            1
-            /^# Benchmark$/ && !done {
-              print ""
-              print ":white_check_mark: **Good job — no unexpected performance regressions in this run.**"
-              done = 1
-            }
-          ' /tmp/summary_body.md > /tmp/summary_body_new.md
-
-          echo "::group::patch review"
-          gh api -X PATCH "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" -f body=@/tmp/summary_body_new.md
-          echo "patch review OK"
-          echo "::endgroup::"
+          if [ -z "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body=@/tmp/status_body.md
+          else
+            gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" -f body=@/tmp/status_body.md
+          fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -70,13 +70,23 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          REVIEW_ID=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Summary -->"))][-1].id // empty')
+          echo "::group::list reviews"
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" > /tmp/reviews.json
+          echo "list reviews OK"
+          echo "::endgroup::"
+
+          REVIEW_ID=$(jq -r '[.[] | select(.body | startswith("<!-- github-benchmark-action-comment(start): Benchmark Summary -->"))][-1].id // empty' /tmp/reviews.json)
+          echo "REVIEW_ID=$REVIEW_ID"
           if [ -z "$REVIEW_ID" ]; then
             echo "No summary comment found yet, skipping"
             exit 0
           fi
+
+          echo "::group::get review body"
           gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" --jq '.body' > /tmp/summary_body.md
+          echo "get review body OK"
+          echo "::endgroup::"
+
           awk '
             1
             /^# Benchmark$/ && !done {
@@ -85,4 +95,8 @@ jobs:
               done = 1
             }
           ' /tmp/summary_body.md > /tmp/summary_body_new.md
+
+          echo "::group::patch review"
           gh api -X PATCH "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" -f body=@/tmp/summary_body_new.md
+          echo "patch review OK"
+          echo "::endgroup::"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,7 +94,7 @@ jobs:
             --jq '[.[] | select(.body | startswith("<!-- benchmark-status-comment -->"))][-1].id // empty')
 
           if [ -z "$COMMENT_ID" ]; then
-            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body=@/tmp/status_body.md
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@/tmp/status_body.md
           else
-            gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" -f body=@/tmp/status_body.md
+            gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" -F body=@/tmp/status_body.md
           fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
           output-file-path: bench-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          alert-threshold: "130%"
+          alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: "@cm45t3r"

--- a/README.md
+++ b/README.md
@@ -263,6 +263,44 @@ patternChain(dataArray, allPatterns, { strict: true });
 
 > **Multi-candle patterns:** Two-candle patterns (Engulfing, Harami, Kicker, Hanging Man, Shooting Star, Piercing Line, Dark Cloud Cover, Tweezers Top/Bottom) return a `match` array with 2 candles. Three-candle patterns (Morning Star, Evening Star, Three White Soldiers, Three Black Crows) return 3. Single-candle patterns return 1. This is driven by the `paramCount` property on each pattern definition.
 
+### Trend-Context Confidence Adjustment
+
+The same candle shape can mean opposite things depending on what preceded it — a small body with a long lower shadow is a bullish `hammer` after a downtrend, but a bearish `hangingMan` after an uptrend. By default, pattern functions don't check this: they're evaluated independently, so the identical candle can be flagged as both, with contradictory signals. Each pattern also has a fixed, context-blind `confidence` in its metadata (e.g. `hammer: 0.7`) that doesn't distinguish a textbook occurrence from a marginal one.
+
+Pass a `trendContext` option to `patternChain` to measure the actual preceding trend and score how well it matches what each pattern expects:
+
+```js
+const { patternChain, allPatterns } = require("candlestick");
+const { enrichWithMetadata } = require("candlestick").metadata;
+
+const matches = patternChain(data, allPatterns, {
+  trendContext: { trendMethod: "sma-slope", trendPeriod: 10 },
+});
+const enriched = enrichWithMetadata(matches);
+
+// Each match now carries a `trendContext` label and a `contextFit` (0-1):
+// { index, pattern: "hammer", match, trendContext: "uptrend", contextFit: 0.13 }
+// { index, pattern: "hangingMan", match, trendContext: "uptrend", contextFit: 0.99 }
+//
+// `enrichWithMetadata` additionally computes `effectiveConfidence` (`confidence * contextFit`)
+// on the trend-aware alternative to the deprecated static `confidence`:
+console.log(enriched[0].metadata.effectiveConfidence); // 0.7 * 0.13 ≈ 0.09 (hammer, wrong context)
+console.log(enriched[1].metadata.effectiveConfidence); // 0.75 * 0.99 ≈ 0.74 (hangingMan, correct context)
+```
+
+Built-in `trendMethod` options: `"sma-slope"` (default), `"ema-slope"`, `"pct-change"` — see `src/trend.js`. As with the [Kicker gap threshold](#gap-significance-threshold-kicker), you can also supply `externalTrend` (a precomputed series) or `trendFn` (a per-candle callback) if you already have a more advanced trend/regime model.
+
+To automatically drop the weaker side of a same-candle, opposite-direction conflict instead of surfacing both, pass `resolveConflicts: true`:
+
+```js
+patternChain(data, allPatterns, {
+  trendContext: { trendMethod: "sma-slope", resolveConflicts: true },
+});
+// Only "hangingMan" survives in the example above; "hammer" (the worse contextFit) is dropped.
+```
+
+This is fully opt-in: omitting `trendContext` preserves `patternChain`'s pre-existing result shape exactly.
+
 ---
 
 ## Pattern Descriptions

--- a/benchmark.js
+++ b/benchmark.js
@@ -14,6 +14,34 @@ function generateCandles(n) {
   });
 }
 
+const WARMUP_RUNS = 1;
+const TIMED_RUNS = 5;
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+// Runs `fn` WARMUP_RUNS times (discarded, lets the JIT warm up) then
+// TIMED_RUNS times, returning the median wall-clock time and the last
+// return value. A single performance.now() sample is too noisy on shared
+// CI runners (GC pauses, neighbor jitter) and was producing spurious
+// performance-alert comments on PRs with no actual code-path change.
+function measureMedian(fn) {
+  let result;
+  for (let i = 0; i < WARMUP_RUNS; i += 1) result = fn();
+  const times = [];
+  for (let i = 0; i < TIMED_RUNS; i += 1) {
+    const start = performance.now();
+    result = fn();
+    times.push(performance.now() - start);
+  }
+  return { time: median(times), result };
+}
+
 function runBenchmark(size, name) {
   console.log(`\n${"=".repeat(60)}`);
   console.log(`Benchmark: ${name} (N=${size.toLocaleString()})`);
@@ -23,32 +51,23 @@ function runBenchmark(size, name) {
   const startMem = process.memoryUsage().heapUsed;
 
   // Precomputation benchmark
-  const precomputeStart = performance.now();
-  const precomputed = precomputeCandleProps(candles);
-  const precomputeEnd = performance.now();
-  const precomputeTime = precomputeEnd - precomputeStart;
+  const { time: precomputeTime, result: precomputed } = measureMedian(() =>
+    precomputeCandleProps(candles),
+  );
 
   // Single pattern benchmark (hammer)
-  const hammerPrecomputeStart = performance.now();
-  const hammerResultsPrecomputed = hammer(precomputed);
-  const hammerPrecomputeEnd = performance.now();
-  const hammerPrecomputeTime = hammerPrecomputeEnd - hammerPrecomputeStart;
+  const { time: hammerPrecomputeTime, result: hammerResultsPrecomputed } =
+    measureMedian(() => hammer(precomputed));
 
-  const hammerRawStart = performance.now();
-  hammer(candles);
-  const hammerRawEnd = performance.now();
-  const hammerRawTime = hammerRawEnd - hammerRawStart;
+  const { time: hammerRawTime } = measureMedian(() => hammer(candles));
 
   // Pattern chain benchmark
-  const chainPrecomputeStart = performance.now();
-  const chainResultsPrecomputed = patternChain(precomputed, allPatterns);
-  const chainPrecomputeEnd = performance.now();
-  const chainPrecomputeTime = chainPrecomputeEnd - chainPrecomputeStart;
+  const { time: chainPrecomputeTime, result: chainResultsPrecomputed } =
+    measureMedian(() => patternChain(precomputed, allPatterns));
 
-  const chainRawStart = performance.now();
-  patternChain(candles, allPatterns);
-  const chainRawEnd = performance.now();
-  const chainRawTime = chainRawEnd - chainRawStart;
+  const { time: chainRawTime } = measureMedian(() =>
+    patternChain(candles, allPatterns),
+  );
 
   const endMem = process.memoryUsage().heapUsed;
   const memDelta = ((endMem - startMem) / 1024 / 1024).toFixed(2);

--- a/benchmark.js
+++ b/benchmark.js
@@ -48,29 +48,33 @@ function runBenchmark(size, name) {
   console.log("=".repeat(60));
 
   const candles = generateCandles(size);
-  const startMem = process.memoryUsage().heapUsed;
 
-  // Precomputation benchmark
-  const { time: precomputeTime, result: precomputed } = measureMedian(() =>
+  // Memory: measured around a single dedicated pass, kept separate from
+  // the warm-up/timed-median loop below — running that loop first would
+  // inflate the heap delta with garbage from the repeated executions.
+  const startMem = process.memoryUsage().heapUsed;
+  const precomputed = precomputeCandleProps(candles);
+  const hammerResultsPrecomputed = hammer(precomputed);
+  hammer(candles);
+  const chainResultsPrecomputed = patternChain(precomputed, allPatterns);
+  patternChain(candles, allPatterns);
+  const endMem = process.memoryUsage().heapUsed;
+  const memDelta = ((endMem - startMem) / 1024 / 1024).toFixed(2);
+
+  // Timing: median of WARMUP_RUNS + TIMED_RUNS repeated executions.
+  const { time: precomputeTime } = measureMedian(() =>
     precomputeCandleProps(candles),
   );
-
-  // Single pattern benchmark (hammer)
-  const { time: hammerPrecomputeTime, result: hammerResultsPrecomputed } =
-    measureMedian(() => hammer(precomputed));
-
+  const { time: hammerPrecomputeTime } = measureMedian(() =>
+    hammer(precomputed),
+  );
   const { time: hammerRawTime } = measureMedian(() => hammer(candles));
-
-  // Pattern chain benchmark
-  const { time: chainPrecomputeTime, result: chainResultsPrecomputed } =
-    measureMedian(() => patternChain(precomputed, allPatterns));
-
+  const { time: chainPrecomputeTime } = measureMedian(() =>
+    patternChain(precomputed, allPatterns),
+  );
   const { time: chainRawTime } = measureMedian(() =>
     patternChain(candles, allPatterns),
   );
-
-  const endMem = process.memoryUsage().heapUsed;
-  const memDelta = ((endMem - startMem) / 1024 / 1024).toFixed(2);
 
   // Results
   console.log("\nPrecomputation:");

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -6,7 +6,7 @@ For a general introduction to candlestick patterns, see [Candlestick chart — W
 
 ## Single Candle Patterns
 
-- **Hammer**: Small body near the top (body < 1/3 of range), long lower shadow (tail ≥ 2× body), small upper shadow. Signals possible bullish reversal.
+- **Hammer**: Small body near the top (body < 1/3 of range), long lower shadow (tail ≥ 2× body), small upper shadow. Signals possible bullish reversal. Note: this is pure geometry — it does not check for a preceding downtrend, so the identical shape after an _uptrend_ is really a **Hanging Man** (bearish), not a hammer. Pass a `trendContext` option to `patternChain` to score/resolve this — see [README: Trend-Context Confidence Adjustment](../README.md#trend-context-confidence-adjustment).
 - **Inverted Hammer**: Small body near the bottom, long upper shadow (wick ≥ 2× body), small lower shadow. Bullish reversal signal.
 - **Doji**: Very small body (body < 10% of range), open ≈ close. Indicates indecision. Candle must have range (high > low).
 - **Marubozu**: Long body (≥ 70% of range) with minimal shadows (< 10% of body). Strong directional move. Bullish Marubozu shows strong buying, Bearish shows strong selling.

--- a/src/contextFit.js
+++ b/src/contextFit.js
@@ -1,0 +1,70 @@
+// contextFit.js
+// Derives, for a given pattern's metadata, which preceding trend direction
+// the pattern actually expects — and scores how well a measured trend value
+// matches that expectation. Implements the core of
+// https://github.com/cm45t3r/candlestick/issues/95.
+//
+// Key insight: a pattern's `direction` (bullish/bearish) is the direction of
+// the SIGNAL it produces, not necessarily the direction of the trend that
+// should precede it:
+// - reversal patterns expect the OPPOSITE preceding trend (e.g. `hammer` is
+//   a bullish-reversal signal, so it expects a preceding DOWNtrend; the
+//   identical candle shape after an UPtrend is `hangingMan`, a bearish
+//   signal, not a hammer — see the worked example in #95).
+// - continuation patterns expect the SAME preceding trend (e.g.
+//   `bullishMarubozu` confirms an ongoing uptrend).
+// - `neutral` direction/type patterns (doji, spinningTop, plain marubozu)
+//   have no trend expectation at all.
+
+const DEFAULT_SENSITIVITY = 5;
+
+/**
+ * @param {{type?: string, direction?: string}} [metadata] - Pattern metadata, e.g. from `patternMetadata.getPatternMetadata`.
+ * @return {number} `1` (expects a preceding uptrend), `-1` (expects a preceding downtrend), or `0` (no expectation, e.g. `direction: "neutral"` or unknown pattern/type).
+ */
+function expectedTrendDirection(metadata) {
+  if (!metadata || metadata.direction === "neutral" || !metadata.direction) {
+    return 0;
+  }
+  const signalSign = metadata.direction === "bullish" ? 1 : -1;
+  if (metadata.type === "reversal") return -signalSign;
+  if (metadata.type === "continuation") return signalSign;
+  return 0;
+}
+
+/**
+ * Scores how well a measured trend value matches a pattern's expected
+ * preceding trend direction. `1` = fully matches expectation, `0` = fully
+ * contradicts it, `0.5` = neutral (no measurable trend, or no expectation
+ * to begin with). Never penalizes missing data: absence of a measurable
+ * trend (e.g. not enough history) resolves to `1` (no adjustment), the same
+ * fail-safe philosophy as #96's gap-significance threshold, applied in the
+ * direction that's safe here — "don't understate confidence when we simply
+ * don't know the context."
+ * @param {number} measuredTrend - Signed fraction from a trend series (e.g. `trend.js`), positive = uptrend, negative = downtrend.
+ * @param {number} expectedDirection - `1`, `-1`, or `0`, from `expectedTrendDirection`.
+ * @param {number} [sensitivity=5] - Higher values saturate to 0/1 faster for a given trend magnitude. `0.5 + sensitivity * (expectedDirection * measuredTrend)`, clamped to `[0, 1]`.
+ * @return {number} Between 0 and 1.
+ */
+function computeContextFit(
+  measuredTrend,
+  expectedDirection,
+  sensitivity = DEFAULT_SENSITIVITY,
+) {
+  if (expectedDirection === 0) return 1;
+  if (
+    measuredTrend === undefined ||
+    measuredTrend === null ||
+    Number.isNaN(measuredTrend)
+  ) {
+    return 1;
+  }
+  const alignment = expectedDirection * measuredTrend;
+  return Math.min(1, Math.max(0, 0.5 + sensitivity * alignment));
+}
+
+module.exports = {
+  expectedTrendDirection,
+  computeContextFit,
+  DEFAULT_SENSITIVITY,
+};

--- a/src/patternChain.js
+++ b/src/patternChain.js
@@ -72,17 +72,25 @@ const allPatterns = [
 ];
 
 const { ensurePrecomputed } = require("./utils.js");
+const { applyTrendContext } = require("./trendContext.js");
+
+/**
+ * @typedef {import("./trendContext.js").TrendContextOptions} TrendContextOptions
+ */
 
 /**
  * Scans a candlestick series for a sequence of patterns.
  * @param {Array<Object>} candles - Array of candlesticks
  * @param {Array<{name: string, fn: function}>} patterns - Array of pattern objects
- * @returns {Array<{ index: number, pattern: string, match: Object|Array<Object> }>} Array of matches
+ * @param {Object} [options]
+ * @param {boolean} [options.strict=false] - Throw on invalid OHLC data instead of silently skipping.
+ * @param {TrendContextOptions} [options.trendContext] - Opt-in trend-context confidence adjustment (#95). Omit entirely to preserve pre-existing output shape exactly.
+ * @returns {Array<{ index: number, pattern: string, match: Object|Array<Object>, trendContext?: "uptrend"|"downtrend"|"sideways", contextFit?: number }>} Array of matches
  */
 function patternChain(
   candles,
   patterns = allPatterns,
-  { strict = false } = {},
+  { strict = false, trendContext } = {},
 ) {
   const precomputed = ensurePrecomputed(candles, strict);
   const results = [];
@@ -96,6 +104,11 @@ function patternChain(
   }
   // Sort by index for chronological order
   results.sort((a, b) => a.index - b.index);
+
+  if (trendContext) {
+    return applyTrendContext(precomputed, results, trendContext);
+  }
+
   return results;
 }
 

--- a/src/patternMetadata.js
+++ b/src/patternMetadata.js
@@ -7,6 +7,18 @@
  * - type: 'reversal' | 'continuation' | 'neutral'
  * - confidence: 0-1 (higher = more reliable)
  * - strength: 'weak' | 'moderate' | 'strong'
+ *
+ * @deprecated `confidence` is a fixed, context-blind value: it does not
+ * distinguish a textbook occurrence of a pattern from a marginal one, and it
+ * does not check whether the preceding trend actually matches what the
+ * pattern expects (see https://github.com/cm45t3r/candlestick/issues/95 for
+ * the worked example — the same candle can qualify as both `hammer` and
+ * `hangingMan`, with opposite signals, and both report their own fixed
+ * `confidence` regardless). Prefer `effectiveConfidence` (`confidence *
+ * contextFit`), available on `enrichWithMetadata` results when
+ * `patternChain` was called with a `trendContext` option. `confidence` is
+ * kept for backward compatibility and is not scheduled for removal before a
+ * major version.
  */
 
 const patternMetadata = {
@@ -236,7 +248,11 @@ function getPatternMetadata(patternName) {
 }
 
 /**
- * Enhance pattern chain results with metadata
+ * Enhance pattern chain results with metadata. When `result.contextFit` is
+ * present (i.e. `patternChain` was called with a `trendContext` option, see
+ * #95), also attaches `contextFit` and `effectiveConfidence` (`confidence *
+ * contextFit`) to the metadata — the trend-aware alternative to the static,
+ * deprecated `confidence` value.
  * @param {Array<Object>} results - Results from patternChain
  * @return {Array<Object>} Results with metadata added
  */
@@ -244,15 +260,21 @@ function enrichWithMetadata(results) {
   return results.map((result) => {
     const metadata = getPatternMetadata(result.pattern);
     if (metadata) {
+      const enrichedMetadata = {
+        type: metadata.type,
+        direction: metadata.direction,
+        confidence: metadata.confidence,
+        strength: metadata.strength,
+        description: metadata.description,
+      };
+      if (typeof result.contextFit === "number") {
+        enrichedMetadata.contextFit = result.contextFit;
+        enrichedMetadata.effectiveConfidence =
+          metadata.confidence * result.contextFit;
+      }
       return {
         ...result,
-        metadata: {
-          type: metadata.type,
-          direction: metadata.direction,
-          confidence: metadata.confidence,
-          strength: metadata.strength,
-          description: metadata.description,
-        },
+        metadata: enrichedMetadata,
       };
     }
     return result;

--- a/src/trend.js
+++ b/src/trend.js
@@ -1,0 +1,92 @@
+// trend.js
+// Built-in trend measures for the trend-context confidence adjustment
+// proposed in https://github.com/cm45t3r/candlestick/issues/95. All measures
+// are signed fractions (positive = uptrend, negative = downtrend), so they
+// are directly comparable to each other and to the pattern's expected
+// direction regardless of price level. Mirrors the style of `volatility.js`.
+
+const DEFAULT_PERIOD = 10;
+
+function rollingMean(values, period) {
+  return values.map((_, index) => {
+    if (index < period) return NaN;
+    let sum = 0;
+    for (let i = index - period + 1; i <= index; i += 1) {
+      sum += values[i];
+    }
+    return sum / period;
+  });
+}
+
+/**
+ * Simple percentage change from `period` candles ago to the current candle's close.
+ * Simplest trend measure: no smoothing, sensitive to the two endpoint candles.
+ * @param {Array<Object>} candles
+ * @param {number} [period=10]
+ * @return {Array<number>} One value per candle; `NaN` where there isn't enough history.
+ */
+function pctChangeSeries(candles, period = DEFAULT_PERIOD) {
+  return candles.map((candle, index) => {
+    if (index < period) return NaN;
+    const past = candles[index - period].close;
+    return (candle.close - past) / past;
+  });
+}
+
+/**
+ * One-step percentage slope of a Simple Moving Average of `period` closes:
+ * `(sma[i] - sma[i-1]) / sma[i-1]`. Smoother/less noisy than `pctChangeSeries`,
+ * at the cost of needing one extra candle of history and reacting slightly later.
+ * @param {Array<Object>} candles
+ * @param {number} [period=10]
+ * @return {Array<number>} One value per candle; `NaN` where there isn't enough history.
+ */
+function smaSlopeSeries(candles, period = DEFAULT_PERIOD) {
+  const closes = candles.map((c) => c.close);
+  const sma = rollingMean(closes, period);
+  return sma.map((value, index) => {
+    if (index === 0 || Number.isNaN(value) || Number.isNaN(sma[index - 1])) {
+      return NaN;
+    }
+    return (value - sma[index - 1]) / sma[index - 1];
+  });
+}
+
+/**
+ * One-step percentage slope of an Exponential Moving Average of `period`
+ * closes (seeded with the SMA of the first `period` closes). More responsive
+ * to recent candles than `smaSlopeSeries`, with less lag.
+ * @param {Array<Object>} candles
+ * @param {number} [period=10]
+ * @return {Array<number>} One value per candle; `NaN` where there isn't enough history.
+ */
+function emaSlopeSeries(candles, period = DEFAULT_PERIOD) {
+  const closes = candles.map((c) => c.close);
+  const multiplier = 2 / (period + 1);
+  const ema = new Array(closes.length).fill(NaN);
+
+  if (closes.length > period - 1) {
+    let seedSum = 0;
+    for (let i = 0; i < period; i += 1) {
+      seedSum += closes[i];
+    }
+    ema[period - 1] = seedSum / period;
+    for (let i = period; i < closes.length; i += 1) {
+      ema[i] = closes[i] * multiplier + ema[i - 1] * (1 - multiplier);
+    }
+  }
+
+  return ema.map((value, index) => {
+    if (index === 0 || Number.isNaN(value) || Number.isNaN(ema[index - 1])) {
+      return NaN;
+    }
+    return (value - ema[index - 1]) / ema[index - 1];
+  });
+}
+
+module.exports = {
+  pctChangeSeries,
+  smaSlopeSeries,
+  emaSlopeSeries,
+  DEFAULT_PERIOD,
+};

--- a/src/trendContext.js
+++ b/src/trendContext.js
@@ -1,0 +1,139 @@
+// trendContext.js
+// Wires the trend-measurement layer (`trend.js`), the shared resolution
+// helper (`seriesResolver.js`, from #97), and the expected-direction scoring
+// (`contextFit.js`) into `patternChain`'s optional `trendContext` option.
+// See https://github.com/cm45t3r/candlestick/issues/95.
+
+const { resolveSeries } = require("./seriesResolver.js");
+const {
+  pctChangeSeries,
+  smaSlopeSeries,
+  emaSlopeSeries,
+  DEFAULT_PERIOD,
+} = require("./trend.js");
+const { getPatternMetadata } = require("./patternMetadata.js");
+const {
+  expectedTrendDirection,
+  computeContextFit,
+} = require("./contextFit.js");
+
+const TREND_BUILTINS = {
+  "sma-slope": smaSlopeSeries,
+  "ema-slope": emaSlopeSeries,
+  "pct-change": pctChangeSeries,
+};
+
+/**
+ * @typedef {Object} TrendContextOptions
+ * @property {"sma-slope"|"ema-slope"|"pct-change"} [trendMethod="sma-slope"] - Built-in trend measure used when `externalTrend`/`trendFn` aren't given. See `trend.js`.
+ * @property {number} [trendPeriod=10] - Lookback window (in candles) for the built-in methods.
+ * @property {Array<number>} [externalTrend] - Precomputed trend series (one signed value per candle, same order as the input array). Takes precedence over `trendMethod`.
+ * @property {function(Array<Object>, number): number} [trendFn] - Callback invoked per candle index to resolve trend lazily. Takes precedence over both `externalTrend` and `trendMethod`.
+ * @property {number} [contextSensitivity=5] - See `contextFit.js`.
+ * @property {boolean} [resolveConflicts=false] - When two matches with opposite `direction` metadata share at least one candle, drop whichever has the lower `contextFit` (ties keep both). Default `false`: surface every match and let the caller filter/rank using `contextFit`.
+ */
+
+/**
+ * Resolves the per-candle trend series for `applyTrendContext`.
+ * @param {Array<Object>} candles
+ * @param {TrendContextOptions} options
+ * @return {Array<number>}
+ */
+function resolveTrendSeries(candles, options) {
+  const { trendMethod, trendPeriod, externalTrend, trendFn } = options;
+  return resolveSeries(candles, {
+    builtins: TREND_BUILTINS,
+    method: trendMethod || "sma-slope",
+    period: trendPeriod ?? DEFAULT_PERIOD,
+    external: externalTrend,
+    fn: trendFn,
+  });
+}
+
+function rangeOf(result) {
+  return [result.index, result.index + result.match.length - 1];
+}
+
+function rangesOverlap(a, b) {
+  return a[0] <= b[1] && b[0] <= a[1];
+}
+
+/**
+ * Drops the lower-`contextFit` match whenever two matches with opposite
+ * `direction` metadata share at least one candle. Ties (equal `contextFit`,
+ * including when neither pattern has trend metadata to compare) keep both.
+ * @param {Array<Object>} results - `patternChain` results, each already carrying `contextFit`.
+ * @return {Array<Object>}
+ */
+function filterConflicts(results) {
+  const drop = new Set();
+  for (let i = 0; i < results.length; i += 1) {
+    const a = results[i];
+    const metaA = getPatternMetadata(a.pattern);
+    if (!metaA || metaA.direction === "neutral") continue;
+
+    for (let j = i + 1; j < results.length; j += 1) {
+      if (drop.has(j)) continue;
+      const b = results[j];
+      const metaB = getPatternMetadata(b.pattern);
+      if (!metaB || metaB.direction === "neutral") continue;
+      if (metaA.direction === metaB.direction) continue;
+      if (!rangesOverlap(rangeOf(a), rangeOf(b))) continue;
+
+      if (a.contextFit > b.contextFit) {
+        drop.add(j);
+      } else if (b.contextFit > a.contextFit) {
+        drop.add(i);
+      }
+    }
+  }
+  return results.filter((_, index) => !drop.has(index));
+}
+
+/**
+ * Attaches `trendContext` (a coarse label) and `contextFit` (0-1) to each
+ * `patternChain` result, based on the trend measured just before the match
+ * begins (never at/after its own start, to avoid the match's own candles
+ * biasing the context they're being evaluated against). Optionally drops
+ * the weaker side of same-candle, opposite-direction conflicts (see
+ * `resolveConflicts`).
+ * @param {Array<Object>} candles - Precomputed candle series.
+ * @param {Array<Object>} results - `patternChain` results (mutated in place with `trendContext`/`contextFit`, then optionally filtered).
+ * @param {TrendContextOptions} options
+ * @return {Array<Object>}
+ */
+function applyTrendContext(candles, results, options) {
+  const { contextSensitivity, resolveConflicts = false } = options;
+  const trendSeries = resolveTrendSeries(candles, options);
+
+  for (const result of results) {
+    const contextIndex = result.index - 1;
+    const measuredTrend =
+      contextIndex >= 0 ? trendSeries[contextIndex] : undefined;
+    const metadata = getPatternMetadata(result.pattern);
+    const expectedDirection = expectedTrendDirection(metadata);
+
+    result.trendContext =
+      measuredTrend === undefined || Number.isNaN(measuredTrend)
+        ? undefined
+        : measuredTrend > 0
+          ? "uptrend"
+          : measuredTrend < 0
+            ? "downtrend"
+            : "sideways";
+    result.contextFit = computeContextFit(
+      measuredTrend,
+      expectedDirection,
+      contextSensitivity,
+    );
+  }
+
+  return resolveConflicts ? filterConflicts(results) : results;
+}
+
+module.exports = {
+  applyTrendContext,
+  resolveTrendSeries,
+  filterConflicts,
+  TREND_BUILTINS,
+};

--- a/test/contextFit.test.js
+++ b/test/contextFit.test.js
@@ -53,6 +53,20 @@ describe("expectedTrendDirection", () => {
     assert.equal(expectedTrendDirection({}), 0);
     assert.equal(expectedTrendDirection({ type: "neutral" }), 0);
   });
+
+  it("returns 0 for a non-neutral direction paired with an unrecognized type", () => {
+    // Not a real patternMetadata combination today, but the function must
+    // not assume `type` is always "reversal"/"continuation" when `direction`
+    // is non-neutral — falls through to the explicit 0 default.
+    assert.equal(
+      expectedTrendDirection({ type: "unknown", direction: "bullish" }),
+      0,
+    );
+    assert.equal(
+      expectedTrendDirection({ type: "unknown", direction: "bearish" }),
+      0,
+    );
+  });
 });
 
 describe("computeContextFit", () => {

--- a/test/contextFit.test.js
+++ b/test/contextFit.test.js
@@ -1,0 +1,94 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  expectedTrendDirection,
+  computeContextFit,
+} = require("../src/contextFit.js");
+
+describe("expectedTrendDirection", () => {
+  it("reversal + bullish direction expects a preceding DOWNtrend (-1)", () => {
+    assert.equal(
+      expectedTrendDirection({ type: "reversal", direction: "bullish" }),
+      -1,
+    );
+  });
+
+  it("reversal + bearish direction expects a preceding UPtrend (1) — the hammer/hangingMan case", () => {
+    assert.equal(
+      expectedTrendDirection({ type: "reversal", direction: "bearish" }),
+      1,
+    );
+  });
+
+  it("continuation + bullish direction expects a preceding UPtrend (1)", () => {
+    assert.equal(
+      expectedTrendDirection({ type: "continuation", direction: "bullish" }),
+      1,
+    );
+  });
+
+  it("continuation + bearish direction expects a preceding DOWNtrend (-1)", () => {
+    assert.equal(
+      expectedTrendDirection({ type: "continuation", direction: "bearish" }),
+      -1,
+    );
+  });
+
+  it("returns 0 for neutral direction regardless of type", () => {
+    assert.equal(
+      expectedTrendDirection({ type: "reversal", direction: "neutral" }),
+      0,
+    );
+    assert.equal(
+      expectedTrendDirection({
+        type: "continuation",
+        direction: "neutral",
+      }),
+      0,
+    );
+  });
+
+  it("returns 0 for missing/unknown metadata", () => {
+    assert.equal(expectedTrendDirection(undefined), 0);
+    assert.equal(expectedTrendDirection({}), 0);
+    assert.equal(expectedTrendDirection({ type: "neutral" }), 0);
+  });
+});
+
+describe("computeContextFit", () => {
+  it("returns 1 (no penalty) when there is no directional expectation", () => {
+    assert.equal(computeContextFit(0.5, 0), 1);
+    assert.equal(computeContextFit(-0.5, 0), 1);
+  });
+
+  it("returns 1 (no penalty) when the measured trend is unavailable", () => {
+    assert.equal(computeContextFit(undefined, 1), 1);
+    assert.equal(computeContextFit(null, 1), 1);
+    assert.equal(computeContextFit(NaN, -1), 1);
+  });
+
+  it("scores above 0.5 when the measured trend matches the expected direction", () => {
+    assert.ok(computeContextFit(0.05, 1, 5) > 0.5); // uptrend, expects uptrend
+    assert.ok(computeContextFit(-0.05, -1, 5) > 0.5); // downtrend, expects downtrend
+  });
+
+  it("scores below 0.5 when the measured trend contradicts the expected direction", () => {
+    assert.ok(computeContextFit(0.05, -1, 5) < 0.5); // uptrend, expects downtrend
+    assert.ok(computeContextFit(-0.05, 1, 5) < 0.5); // downtrend, expects uptrend
+  });
+
+  it("matches the documented formula exactly for a mid-range case", () => {
+    // 0.5 + sensitivity * (expectedDirection * measuredTrend)
+    assert.ok(Math.abs(computeContextFit(0.02, 1, 5) - 0.6) < 1e-12); // 0.5 + 5*0.02
+    assert.ok(Math.abs(computeContextFit(0.02, -1, 5) - 0.4) < 1e-12); // 0.5 - 5*0.02
+  });
+
+  it("clamps to [0, 1] for large aligned/contradicting trends", () => {
+    assert.equal(computeContextFit(1, 1, 5), 1);
+    assert.equal(computeContextFit(1, -1, 5), 0);
+  });
+
+  it("uses the default sensitivity (5) when not specified", () => {
+    assert.equal(computeContextFit(0.02, 1), computeContextFit(0.02, 1, 5));
+  });
+});

--- a/test/patternChain.test.js
+++ b/test/patternChain.test.js
@@ -211,3 +211,63 @@ describe("patternChain strict mode", () => {
     assert.doesNotThrow(() => patternChain(valid, undefined, { strict: true }));
   });
 });
+
+describe("patternChain trendContext option (#95)", () => {
+  // Clean uptrend, then the hammer/hangingMan-shaped candle from #95's
+  // worked example (see test/trendContext.test.js for the full annotation).
+  const candles = [
+    { open: 100, high: 101, low: 99, close: 100 },
+    { open: 100, high: 106, low: 99, close: 105 },
+    { open: 105, high: 111, low: 104, close: 110 },
+    { open: 110, high: 117, low: 109, close: 116 },
+    { open: 116, high: 123, low: 115, close: 122 },
+    { open: 122, high: 130, low: 121, close: 128 },
+    { open: 128, high: 136, low: 127, close: 134 },
+    { open: 134, high: 137, low: 132, close: 136 },
+    { open: 140, high: 141, low: 133, close: 138 },
+  ];
+
+  it("omitting trendContext preserves the exact pre-existing result shape", () => {
+    const results = patternChain(candles);
+    for (const result of results) {
+      assert.deepStrictEqual(Object.keys(result), [
+        "index",
+        "pattern",
+        "match",
+      ]);
+    }
+  });
+
+  it("with trendContext, results carry trendContext/contextFit and correctly rank the hammer/hangingMan conflict", () => {
+    const results = patternChain(candles, allPatterns, {
+      trendContext: {
+        trendMethod: "sma-slope",
+        trendPeriod: 3,
+        contextSensitivity: 10,
+      },
+    });
+    const hangingMan = results.find((r) => r.pattern === "hangingMan");
+    const hammer = results.find((r) => r.pattern === "hammer" && r.index === 8);
+
+    assert.ok(hangingMan);
+    assert.ok(hammer);
+    assert.equal(hangingMan.trendContext, "uptrend");
+    assert.ok(hangingMan.contextFit > hammer.contextFit);
+  });
+
+  it("resolveConflicts: true removes the lower-contextFit side of the hammer/hangingMan conflict", () => {
+    const results = patternChain(candles, allPatterns, {
+      trendContext: {
+        trendMethod: "sma-slope",
+        trendPeriod: 3,
+        contextSensitivity: 10,
+        resolveConflicts: true,
+      },
+    });
+    const patterns = results.map((r) => r.pattern);
+    assert.ok(patterns.includes("hangingMan"));
+    assert.ok(
+      !patterns.some((p, i) => p === "hammer" && results[i].index === 8),
+    );
+  });
+});

--- a/test/patternMetadata.test.js
+++ b/test/patternMetadata.test.js
@@ -46,6 +46,24 @@ describe("patternMetadata", () => {
       const enriched = enrichWithMetadata(results);
       assert.equal(enriched[0].metadata, undefined);
     });
+
+    it("does not add contextFit/effectiveConfidence when the result has no contextFit (#95)", () => {
+      const results = [{ index: 0, pattern: "hammer", match: [] }];
+      const enriched = enrichWithMetadata(results);
+      assert.equal("contextFit" in enriched[0].metadata, false);
+      assert.equal("effectiveConfidence" in enriched[0].metadata, false);
+    });
+
+    it("adds contextFit/effectiveConfidence = confidence * contextFit when the result carries a contextFit (#95)", () => {
+      const results = [
+        { index: 0, pattern: "hammer", match: [], contextFit: 0.4 },
+      ];
+      const enriched = enrichWithMetadata(results);
+      assert.equal(enriched[0].metadata.contextFit, 0.4);
+      assert.ok(
+        Math.abs(enriched[0].metadata.effectiveConfidence - 0.7 * 0.4) < 1e-12,
+      );
+    });
   });
 
   describe("filterByConfidence", () => {

--- a/test/trend.test.js
+++ b/test/trend.test.js
@@ -1,0 +1,67 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  pctChangeSeries,
+  smaSlopeSeries,
+  emaSlopeSeries,
+} = require("../src/trend.js");
+
+// Hand-derived fixture (closes = [10, 11, 12, 11, 13, 14]).
+const candles = [
+  { close: 10 },
+  { close: 11 },
+  { close: 12 },
+  { close: 11 },
+  { close: 13 },
+  { close: 14 },
+];
+
+describe("trend", () => {
+  it("pctChangeSeries: NaN before enough history, matches manual calculation", () => {
+    const result = pctChangeSeries(candles, 2);
+    assert.equal(Number.isNaN(result[0]), true);
+    assert.equal(Number.isNaN(result[1]), true);
+    assert.ok(Math.abs(result[2] - 0.2) < 1e-12); // (12-10)/10
+    assert.ok(Math.abs(result[3] - 0) < 1e-12); // (11-11)/11
+    assert.ok(Math.abs(result[4] - 0.08333333333333333) < 1e-12); // (13-12)/12
+    assert.ok(Math.abs(result[5] - 0.2727272727272727) < 1e-12); // (14-11)/11
+  });
+
+  it("smaSlopeSeries: NaN before enough history (needs one extra candle beyond the SMA window), matches manual calculation", () => {
+    const result = smaSlopeSeries(candles, 2);
+    assert.equal(Number.isNaN(result[0]), true);
+    assert.equal(Number.isNaN(result[1]), true);
+    assert.equal(Number.isNaN(result[2]), true);
+    assert.ok(Math.abs(result[3] - 0) < 1e-12);
+    assert.ok(Math.abs(result[4] - 0.043478260869565216) < 1e-12);
+    assert.ok(Math.abs(result[5] - 0.125) < 1e-12);
+  });
+
+  it("emaSlopeSeries: NaN before the seed is available, matches manual calculation", () => {
+    const result = emaSlopeSeries(candles, 2);
+    assert.equal(Number.isNaN(result[0]), true);
+    assert.equal(Number.isNaN(result[1]), true);
+    assert.ok(Math.abs(result[2] - 0.09523809523809523) < 1e-9);
+    assert.ok(Math.abs(result[3] - -0.028985507246376708) < 1e-9);
+    assert.ok(Math.abs(result[4] - 0.10945273631840788) < 1e-9);
+    assert.ok(Math.abs(result[5] - 0.08669656203288478) < 1e-9);
+  });
+
+  it("all series have the same length as the input", () => {
+    assert.equal(pctChangeSeries(candles, 2).length, candles.length);
+    assert.equal(smaSlopeSeries(candles, 2).length, candles.length);
+    assert.equal(emaSlopeSeries(candles, 2).length, candles.length);
+  });
+
+  it("uses the default period (10) when not specified", () => {
+    const longCandles = Array.from({ length: 15 }, (_, i) => ({
+      close: 100 + i,
+    }));
+    assert.equal(Number.isNaN(pctChangeSeries(longCandles)[9]), true);
+    assert.equal(
+      Number.isNaN(pctChangeSeries(longCandles)[10]),
+      false,
+      "pctChangeSeries default period should produce a value by index 10",
+    );
+  });
+});

--- a/test/trendContext.test.js
+++ b/test/trendContext.test.js
@@ -1,0 +1,151 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  applyTrendContext,
+  resolveTrendSeries,
+  filterConflicts,
+} = require("../src/trendContext.js");
+const { precomputeCandleProps } = require("../src/utils.js");
+
+// Clean, steady uptrend (~5-6%/candle for 6 candles), then the exact
+// hammer/hangingMan-shaped candle used in #95's worked example: candles[7]
+// (bullish) + candles[8] (small body near the top, long lower shadow, gap
+// up) form `hangingMan` (index 7, spans [7,8]); candles[8] alone also
+// qualifies as `hammer` (index 8) — the real-world contradiction #95 documents.
+const candles = precomputeCandleProps([
+  { open: 100, high: 101, low: 99, close: 100 },
+  { open: 100, high: 106, low: 99, close: 105 },
+  { open: 105, high: 111, low: 104, close: 110 },
+  { open: 110, high: 117, low: 109, close: 116 },
+  { open: 116, high: 123, low: 115, close: 122 },
+  { open: 122, high: 130, low: 121, close: 128 },
+  { open: 128, high: 136, low: 127, close: 134 },
+  { open: 134, high: 137, low: 132, close: 136 },
+  { open: 140, high: 141, low: 133, close: 138 },
+]);
+
+describe("resolveTrendSeries", () => {
+  it("defaults to sma-slope when no trendMethod is given", () => {
+    const withDefault = resolveTrendSeries(candles, { trendPeriod: 3 });
+    const explicit = resolveTrendSeries(candles, {
+      trendMethod: "sma-slope",
+      trendPeriod: 3,
+    });
+    assert.deepStrictEqual(withDefault, explicit);
+  });
+
+  it("supports ema-slope and pct-change by name", () => {
+    assert.doesNotThrow(() =>
+      resolveTrendSeries(candles, { trendMethod: "ema-slope", trendPeriod: 3 }),
+    );
+    assert.doesNotThrow(() =>
+      resolveTrendSeries(candles, {
+        trendMethod: "pct-change",
+        trendPeriod: 3,
+      }),
+    );
+  });
+
+  it("externalTrend takes precedence over trendMethod", () => {
+    const external = candles.map(() => 0.5);
+    const result = resolveTrendSeries(candles, {
+      trendMethod: "sma-slope",
+      externalTrend: external,
+    });
+    assert.deepStrictEqual(result, external);
+  });
+});
+
+describe("applyTrendContext", () => {
+  const baseResults = () => [
+    { index: 7, pattern: "hangingMan", match: candles.slice(7, 9) },
+    { index: 8, pattern: "hammer", match: candles.slice(8, 9) },
+  ];
+
+  it("attaches a higher contextFit to hangingMan than to hammer in a clear uptrend", () => {
+    const results = applyTrendContext(candles, baseResults(), {
+      trendMethod: "sma-slope",
+      trendPeriod: 3,
+      contextSensitivity: 10,
+    });
+    const hangingMan = results.find((r) => r.pattern === "hangingMan");
+    const hammer = results.find((r) => r.pattern === "hammer");
+
+    assert.equal(hangingMan.trendContext, "uptrend");
+    assert.equal(hammer.trendContext, "uptrend");
+    assert.ok(
+      hangingMan.contextFit > 0.5,
+      "hangingMan should score above neutral",
+    );
+    assert.ok(hammer.contextFit < 0.5, "hammer should score below neutral");
+    assert.ok(hangingMan.contextFit > hammer.contextFit);
+  });
+
+  it("leaves trendContext undefined for a match at index 0 (no preceding candle to measure)", () => {
+    const results = applyTrendContext(
+      candles,
+      [{ index: 0, pattern: "hammer", match: candles.slice(0, 1) }],
+      { trendMethod: "sma-slope", trendPeriod: 3 },
+    );
+    assert.equal(results[0].trendContext, undefined);
+    assert.equal(results[0].contextFit, 1); // fails safe: no penalty when unmeasurable
+  });
+
+  it("resolveConflicts (default false) keeps both sides of a same-candle, opposite-direction conflict", () => {
+    const results = applyTrendContext(candles, baseResults(), {
+      trendMethod: "sma-slope",
+      trendPeriod: 3,
+      contextSensitivity: 10,
+    });
+    assert.equal(results.length, 2);
+  });
+
+  it("resolveConflicts: true drops the lower-contextFit side of the conflict", () => {
+    const results = applyTrendContext(candles, baseResults(), {
+      trendMethod: "sma-slope",
+      trendPeriod: 3,
+      contextSensitivity: 10,
+      resolveConflicts: true,
+    });
+    assert.deepStrictEqual(
+      results.map((r) => r.pattern),
+      ["hangingMan"],
+    );
+  });
+});
+
+describe("filterConflicts", () => {
+  it("keeps both matches when they don't share any candle", () => {
+    const results = [
+      { index: 0, pattern: "hammer", match: [{}], contextFit: 0.9 },
+      { index: 5, pattern: "hangingMan", match: [{}, {}], contextFit: 0.1 },
+    ];
+    assert.deepStrictEqual(filterConflicts(results), results);
+  });
+
+  it("keeps both matches when they share the same direction", () => {
+    // bullishHammer and bullishMarubozu are both "bullish" direction;
+    // overlap alone shouldn't trigger a drop.
+    const results = [
+      { index: 3, pattern: "bullishHammer", match: [{}], contextFit: 0.9 },
+      { index: 3, pattern: "bullishMarubozu", match: [{}], contextFit: 0.2 },
+    ];
+    assert.deepStrictEqual(filterConflicts(results), results);
+  });
+
+  it("keeps both matches on an exact contextFit tie", () => {
+    const results = [
+      { index: 3, pattern: "hammer", match: [{}], contextFit: 0.5 },
+      { index: 2, pattern: "hangingMan", match: [{}, {}], contextFit: 0.5 },
+    ];
+    assert.deepStrictEqual(filterConflicts(results), results);
+  });
+
+  it("ignores neutral-direction patterns entirely (never conflict)", () => {
+    const results = [
+      { index: 3, pattern: "doji", match: [{}], contextFit: 0.9 },
+      { index: 3, pattern: "hammer", match: [{}], contextFit: 0.1 },
+    ];
+    assert.deepStrictEqual(filterConflicts(results), results);
+  });
+});

--- a/test/trendContext.test.js
+++ b/test/trendContext.test.js
@@ -91,6 +91,22 @@ describe("applyTrendContext", () => {
     assert.equal(results[0].contextFit, 1); // fails safe: no penalty when unmeasurable
   });
 
+  it("labels a declining series as a downtrend", () => {
+    const decliningCandles = precomputeCandleProps([
+      { open: 138, high: 141, low: 133, close: 136 },
+      { open: 134, high: 137, low: 127, close: 130 },
+      { open: 130, high: 133, low: 121, close: 124 },
+      { open: 124, high: 128, low: 115, close: 118 },
+      { open: 118, high: 122, low: 109, close: 112 },
+    ]);
+    const results = applyTrendContext(
+      decliningCandles,
+      [{ index: 4, pattern: "hammer", match: decliningCandles.slice(4, 5) }],
+      { trendMethod: "sma-slope", trendPeriod: 2 },
+    );
+    assert.equal(results[0].trendContext, "downtrend");
+  });
+
   it("resolveConflicts (default false) keeps both sides of a same-candle, opposite-direction conflict", () => {
     const results = applyTrendContext(candles, baseResults(), {
       trendMethod: "sma-slope",
@@ -147,5 +163,25 @@ describe("filterConflicts", () => {
       { index: 3, pattern: "hammer", match: [{}], contextFit: 0.1 },
     ];
     assert.deepStrictEqual(filterConflicts(results), results);
+  });
+
+  it("drops the FIRST match when the second (later) one has the higher contextFit", () => {
+    // Regression check for the `b.contextFit > a.contextFit` branch: order
+    // in the results array must not determine which side survives, only
+    // contextFit should.
+    const weakHammer = {
+      index: 5,
+      pattern: "hammer",
+      match: [{}],
+      contextFit: 0.2,
+    };
+    const strongHangingMan = {
+      index: 4,
+      pattern: "hangingMan",
+      match: [{}, {}],
+      contextFit: 0.8,
+    };
+    const results = [weakHammer, strongHangingMan];
+    assert.deepStrictEqual(filterConflicts(results), [strongHangingMan]);
   });
 });

--- a/test/trendContext.test.js
+++ b/test/trendContext.test.js
@@ -107,6 +107,20 @@ describe("applyTrendContext", () => {
     assert.equal(results[0].trendContext, "downtrend");
   });
 
+  it('labels a flat (no-change) series as "sideways"', () => {
+    const flatCandles = precomputeCandleProps([
+      { open: 100, high: 101, low: 99, close: 100 },
+      { open: 100, high: 101, low: 99, close: 100 },
+      { open: 100, high: 101, low: 99, close: 100 },
+    ]);
+    const results = applyTrendContext(
+      flatCandles,
+      [{ index: 2, pattern: "hammer", match: flatCandles.slice(2, 3) }],
+      { trendMethod: "pct-change", trendPeriod: 1 },
+    );
+    assert.equal(results[0].trendContext, "sideways");
+  });
+
   it("resolveConflicts (default false) keeps both sides of a same-candle, opposite-direction conflict", () => {
     const results = applyTrendContext(candles, baseResults(), {
       trendMethod: "sma-slope",
@@ -183,5 +197,18 @@ describe("filterConflicts", () => {
     };
     const results = [weakHammer, strongHangingMan];
     assert.deepStrictEqual(filterConflicts(results), [strongHangingMan]);
+  });
+
+  it("keeps both matches when the second pattern has no known metadata", () => {
+    const results = [
+      { index: 3, pattern: "hammer", match: [{}], contextFit: 0.9 },
+      {
+        index: 3,
+        pattern: "totallyUnknownPattern",
+        match: [{}],
+        contextFit: 0.1,
+      },
+    ];
+    assert.deepStrictEqual(filterConflicts(results), results);
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,9 +33,49 @@ export interface OHLCExtended extends OHLC {
 export interface PatternMetadata {
   type: "reversal" | "continuation" | "neutral";
   direction: "bullish" | "bearish" | "neutral";
+  /**
+   * @deprecated Fixed, context-blind reliability score — does not check
+   * whether the preceding trend matches what the pattern expects (see
+   * https://github.com/cm45t3r/candlestick/issues/95). Prefer
+   * `effectiveConfidence` (present when `patternChain` was called with a
+   * `trendContext` option). Kept for backward compatibility; not scheduled
+   * for removal before a major version.
+   */
   confidence: number;
   strength: "weak" | "moderate" | "strong";
   description: string;
+  /** How well the measured preceding trend matches this pattern's expected direction (0-1). Only present when `patternChain` was called with a `trendContext` option. See `TrendContextOptions`. */
+  contextFit?: number;
+  /** `confidence * contextFit`. The trend-aware alternative to the deprecated static `confidence`. Only present alongside `contextFit`. */
+  effectiveConfidence?: number;
+}
+
+/**
+ * Built-in trend measures for `TrendContextOptions.trendMethod`. All three
+ * require `trendPeriod` (or one extra candle beyond it) prior candles to
+ * produce a value (`NaN`/no context otherwise). See `src/trend.js`.
+ */
+export type TrendMethod = "sma-slope" | "ema-slope" | "pct-change";
+
+/**
+ * Options enabling the optional trend-context confidence adjustment for
+ * `patternChain` (#95). Fully opt-in: omitting this object preserves the
+ * pre-existing `patternChain` result shape exactly (no `trendContext`/
+ * `contextFit` fields, no filtering).
+ */
+export interface TrendContextOptions {
+  /** Built-in trend measure used when `externalTrend`/`trendFn` aren't given. Defaults to `"sma-slope"`. */
+  trendMethod?: TrendMethod;
+  /** Lookback window (in candles) for the built-in methods. Defaults to `10`. */
+  trendPeriod?: number;
+  /** Precomputed trend series (one signed value per candle, same order as the input array). Takes precedence over `trendMethod`. */
+  externalTrend?: number[];
+  /** Callback invoked per candle index to resolve trend lazily. Takes precedence over both `externalTrend` and `trendMethod`. */
+  trendFn?: (candles: OHLC[], index: number) => number;
+  /** Sensitivity of `contextFit` to the measured trend's magnitude. Defaults to `5`. See `src/contextFit.js`. */
+  contextSensitivity?: number;
+  /** When two matches with opposite `direction` metadata share at least one candle, drop whichever has the lower `contextFit` (ties keep both). Defaults to `false`: surface every match and let the caller filter/rank using `contextFit`. */
+  resolveConflicts?: boolean;
 }
 
 /**
@@ -46,6 +86,10 @@ export interface PatternMatch {
   pattern: string;
   match: OHLC[] | OHLCExtended[];
   metadata?: PatternMetadata;
+  /** Coarse label for the trend measured just before this match begins. Only present when `patternChain` was called with a `trendContext` option; `undefined` when there isn't enough preceding history to measure it. */
+  trendContext?: "uptrend" | "downtrend" | "sideways";
+  /** How well the measured preceding trend matches this pattern's expected direction (0-1). Only present alongside `trendContext` option usage. */
+  contextFit?: number;
 }
 
 /**
@@ -496,7 +540,7 @@ export const allPatterns: PatternDefinition[];
 export function patternChain(
   candles: OHLC[],
   patterns?: PatternDefinition[],
-  options?: { strict?: boolean },
+  options?: { strict?: boolean; trendContext?: TrendContextOptions },
 ): PatternMatch[];
 
 // ========== Utilities Export ==========


### PR DESCRIPTION
## Summary

Implements #95, reusing the shared resolution helper from #97/#98 (`src/seriesResolver.js`).

- Adds an opt-in `trendContext` option to `patternChain` measuring the actual preceding trend and scoring how well it matches what each pattern expects — resolving the real contradiction documented in #95: the identical candle shape can qualify as both `hammer` (bullish reversal, expects a preceding **downtrend**) and `hangingMan` (bearish reversal, expects a preceding **uptrend**), with opposite signals.
- Three built-in `trendMethod` options (`"sma-slope"` default, `"ema-slope"`, `"pct-change"`, `src/trend.js`), plus `externalTrend`/`trendFn` escape hatches for callers with a more advanced trend/regime model (this package implements neither GARCH nor an HMM itself — same reasoning as #96).
- `src/contextFit.js` derives each pattern's **expected** preceding-trend direction directly from its existing `type`+`direction` metadata (no new metadata needed): reversal patterns expect the *opposite* trend, continuation patterns expect the *same* trend, neutral patterns expect nothing.
- Each match gets `trendContext` (a coarse label: `"uptrend"|"downtrend"|"sideways"`) and `contextFit` (0-1). `enrichWithMetadata` additionally computes `effectiveConfidence` (`confidence * contextFit`).
- **`confidence` is now marked `@deprecated`** in JSDoc/types (per #95's explicit ask) — kept for backward compatibility, not scheduled for removal before a major version.
- `resolveConflicts: true` optionally drops the lower-`contextFit` side of a same-candle, opposite-direction conflict; default `false` surfaces both and lets the caller filter/rank.
- **Fully backward compatible**: omitting `trendContext` preserves `patternChain`'s exact pre-existing result shape (verified by an explicit test asserting `Object.keys(result)` is unchanged), and the static `confidence` field's value is unchanged.

### Worked example (real numbers, from a clean synthetic uptrend + the exact hammer/hangingMan candle shape from #95)

```js
patternChain(candles, allPatterns, { trendContext: { trendMethod: "sma-slope", trendPeriod: 3, contextSensitivity: 10 } });
// hangingMan: trendContext "uptrend", contextFit 0.992, effectiveConfidence ≈ 0.74  (correct: matches its bearish-after-uptrend expectation)
// hammer:     trendContext "uptrend", contextFit 0.135, effectiveConfidence ≈ 0.09  (correctly penalized: contradicts its bullish-after-downtrend expectation)
```

## Test plan

- [x] `npm test` — 409/409 passing (388 pre-existing + 21 new, zero pre-existing tests modified)
- [x] `npm run lint` — no new errors (4 pre-existing warnings in `scripts/update-bench.js`, untouched)
- [x] `npx prettier --check` — clean
- [x] `npm run bench` — completes successfully; the no-`trendContext` hot path is unchanged code (a single falsy `if` check), no algorithmic regression
- [x] New unit tests for `trend.js` (all 3 formulas hand-derived and independently verified against a fixture), `contextFit.js` (the full type×direction → expected-direction matrix, clamping, fail-safe on missing data), `trendContext.js` (series resolution precedence, `applyTrendContext`'s index-1 lookback and undefined-at-index-0 behavior, `filterConflicts`' overlap/same-direction/tie rules)
- [x] `patternChain.test.js`: backward-compat shape assertion, end-to-end hammer/hangingMan ranking, `resolveConflicts: true` dropping the correct side
- [x] `patternMetadata.test.js`: `effectiveConfidence`/`contextFit` only appear on `enrichWithMetadata` output when the underlying result actually carries a `contextFit`
- [x] `types/index.d.ts` updated: `TrendMethod`, `TrendContextOptions`, extended `PatternMatch`/`PatternMetadata`, `confidence` marked `@deprecated`
- [x] `README.md` (new "Trend-Context Confidence Adjustment" section) and `docs/PATTERNS.md` (Hammer entry) updated
- [x] Manual CJS/ESM smoke test of `patternChain(..., { trendContext: {...} })`

Closes #95.