### PR TITLE
fix(streaming): drop duplicate matches at chunk boundaries

### DIFF
--- a/src/streaming.js
+++ b/src/streaming.js
@@ -50,10 +50,13 @@ function createStream(options = {}) {
   let buffer = [];
   let globalOffset = 0;
   let totalProcessed = 0;
-  const maxPatternSize = Math.max(...patternFns.map((p) => p.paramCount || 1));
+  // Every pattern carries a numeric paramCount: the built-ins define it, and
+  // plugins.registerPattern() normalizes and validates it (1-10). Enforced by
+  // the "every pattern declares a numeric paramCount" test.
   const paramCountByName = new Map(
-    patternFns.map((p) => [p.name, p.paramCount || 1]),
+    patternFns.map((p) => [p.name, p.paramCount]),
   );
+  const maxPatternSize = Math.max(...paramCountByName.values());
 
   /**
    * The carry-over overlap is sized for the longest pattern (`maxPatternSize`),
@@ -69,7 +72,8 @@ function createStream(options = {}) {
       return results;
     }
     return results.filter(
-      (r) => r.index >= maxPatternSize - (paramCountByName.get(r.pattern) || 1),
+      // every r.pattern came from patternFns, so the lookup always hits
+      (r) => r.index >= maxPatternSize - paramCountByName.get(r.pattern),
     );
   }
 

--- a/src/streaming.js
+++ b/src/streaming.js
@@ -51,6 +51,27 @@ function createStream(options = {}) {
   let globalOffset = 0;
   let totalProcessed = 0;
   const maxPatternSize = Math.max(...patternFns.map((p) => p.paramCount || 1));
+  const paramCountByName = new Map(
+    patternFns.map((p) => [p.name, p.paramCount || 1]),
+  );
+
+  /**
+   * The carry-over overlap is sized for the longest pattern (`maxPatternSize`),
+   * so shorter patterns anchored at the start of a non-first chunk were already
+   * detected and emitted by the previous chunk. Drop those repeats: a pattern of
+   * size `k` at local index `i` is a repeat when `i < maxPatternSize - k`.
+   * @param {Array<Object>} results - patternChain results, local indices
+   * @param {boolean} isFirstChunk - first chunk has no preceding overlap
+   * @return {Array<Object>} results with boundary repeats removed
+   */
+  function dropOverlapRepeats(results, isFirstChunk) {
+    if (isFirstChunk) {
+      return results;
+    }
+    return results.filter(
+      (r) => r.index >= maxPatternSize - (paramCountByName.get(r.pattern) || 1),
+    );
+  }
 
   /**
    * Process a chunk of data
@@ -70,9 +91,12 @@ function createStream(options = {}) {
       const overlap = buffer.slice(chunkSize - maxPatternSize + 1);
 
       // Detect patterns in this chunk
-      const results = candlestick.patternChain(toProcess, patternFns, {
-        strict,
-      });
+      const results = dropOverlapRepeats(
+        candlestick.patternChain(toProcess, patternFns, {
+          strict,
+        }),
+        globalOffset === 0,
+      );
 
       // Enrich with metadata if requested
       const finalResults = enrichMetadata
@@ -112,7 +136,10 @@ function createStream(options = {}) {
 
     // Process remaining buffer
     if (buffer.length > 0) {
-      const results = candlestick.patternChain(buffer, patternFns, { strict });
+      const results = dropOverlapRepeats(
+        candlestick.patternChain(buffer, patternFns, { strict }),
+        globalOffset === 0,
+      );
       const finalResults = enrichMetadata
         ? candlestick.metadata.enrichWithMetadata(results)
         : results;

--- a/test/streaming.test.js
+++ b/test/streaming.test.js
@@ -1,6 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { createStream, processLargeDataset } = require("../src/streaming.js");
+const { patternChain, allPatterns } = require("../index.js");
 
 // Helper to generate test data
 function generateCandles(count) {
@@ -15,6 +16,42 @@ function generateCandles(count) {
     });
   }
   return candles;
+}
+
+// Deterministic (no Math.random) so batch and streaming see identical input.
+function generateDeterministicCandles(count) {
+  const candles = [];
+  for (let i = 0; i < count; i++) {
+    const base = 100 + Math.sin(i / 50) * 20 + (i % 7) * 0.3;
+    const close = base + Math.sin(i / 3) * 1.5;
+    candles.push({
+      open: base,
+      high: Math.max(base, close) + 1,
+      low: Math.min(base, close) - 1.4,
+      close,
+    });
+  }
+  return candles;
+}
+
+// Collect streaming matches as sorted "index|pattern" keys.
+function streamKeys(data, chunkSize, feedSize = chunkSize) {
+  const keys = [];
+  const stream = createStream({
+    chunkSize,
+    onMatch: (r) => keys.push(`${r.index}|${r.pattern}`),
+  });
+  for (let i = 0; i < data.length; i += feedSize) {
+    stream.process(data.slice(i, i + feedSize));
+  }
+  stream.end();
+  return keys.sort();
+}
+
+function batchKeys(data) {
+  return patternChain(data, allPatterns)
+    .map((r) => `${r.index}|${r.pattern}`)
+    .sort();
 }
 
 describe("Streaming API", () => {
@@ -426,6 +463,68 @@ describe("Streaming API", () => {
 
       const stream = createStream({ patterns: ["hammer"], chunkSize: BIG + 1 });
       assert.doesNotThrow(() => stream.process(chunk));
+    });
+  });
+  describe("equivalence with batch patternChain", () => {
+    // Regression for #115: the carry-over overlap is sized for the longest
+    // pattern (maxPatternSize), so patterns shorter than that were re-detected
+    // at the start of every non-first chunk and emitted twice.
+    it("emits exactly the batch matches across many chunk boundaries", () => {
+      const data = generateDeterministicCandles(5000);
+      assert.deepEqual(streamKeys(data, 1000), batchKeys(data));
+    });
+
+    it("emits no duplicate matches at chunk boundaries", () => {
+      const data = generateDeterministicCandles(5000);
+      const keys = streamKeys(data, 1000);
+      assert.equal(
+        keys.length,
+        new Set(keys).size,
+        "streaming emitted duplicate (index, pattern) pairs",
+      );
+    });
+
+    it("matches batch output for a range of chunk sizes", () => {
+      const data = generateDeterministicCandles(3000);
+      const expected = batchKeys(data);
+      for (const chunkSize of [3, 4, 7, 64, 999, 1000, 1001]) {
+        assert.deepEqual(
+          streamKeys(data, chunkSize),
+          expected,
+          `chunkSize ${chunkSize} diverged from batch`,
+        );
+      }
+    });
+
+    it("matches batch output when feed size is not aligned to chunk size", () => {
+      const data = generateDeterministicCandles(3000);
+      assert.deepEqual(streamKeys(data, 1000, 333), batchKeys(data));
+    });
+
+    it("matches batch output when the data never fills a chunk", () => {
+      const data = generateDeterministicCandles(500);
+      assert.deepEqual(streamKeys(data, 1000), batchKeys(data));
+    });
+
+    it("keeps single-candle patterns unduplicated at boundaries", () => {
+      const data = generateDeterministicCandles(4000);
+      const keys = [];
+      const stream = createStream({
+        patterns: ["hammer"],
+        chunkSize: 1000,
+        onMatch: (r) => keys.push(r.index),
+      });
+      for (let i = 0; i < data.length; i += 1000) {
+        stream.process(data.slice(i, i + 1000));
+      }
+      stream.end();
+      assert.equal(keys.length, new Set(keys).size);
+      assert.deepEqual(
+        [...keys].sort((a, b) => a - b),
+        patternChain(data, [allPatterns.find((p) => p.name === "hammer")]).map(
+          (r) => r.index,
+        ),
+      );
     });
   });
 });

--- a/test/streaming.test.js
+++ b/test/streaming.test.js
@@ -1,7 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { createStream, processLargeDataset } = require("../src/streaming.js");
-const { patternChain, allPatterns } = require("../index.js");
+const { patternChain, allPatterns, plugins } = require("../index.js");
 
 // Helper to generate test data
 function generateCandles(count) {
@@ -465,6 +465,37 @@ describe("Streaming API", () => {
       assert.doesNotThrow(() => stream.process(chunk));
     });
   });
+  describe("pattern size invariant", () => {
+    // The chunk-overlap math in createStream indexes paramCount directly.
+    // If a pattern ever shipped without it, maxPatternSize would become NaN
+    // and every boundary comparison would silently fail open.
+    it("every built-in pattern declares a numeric paramCount", () => {
+      for (const pattern of allPatterns) {
+        assert.equal(
+          typeof pattern.paramCount,
+          "number",
+          `pattern "${pattern.name}" has no numeric paramCount`,
+        );
+        assert.ok(
+          Number.isInteger(pattern.paramCount) && pattern.paramCount >= 1,
+          `pattern "${pattern.name}" has an invalid paramCount: ${pattern.paramCount}`,
+        );
+      }
+    });
+
+    it("registerPattern normalizes a missing paramCount to 1", () => {
+      const def = plugins.registerPattern({
+        name: "paramCountDefaultProbe",
+        fn: () => [],
+      });
+      try {
+        assert.equal(def.paramCount, 1);
+      } finally {
+        plugins.unregisterPattern("paramCountDefaultProbe");
+      }
+    });
+  });
+
   describe("equivalence with batch patternChain", () => {
     // Regression for #115: the carry-over overlap is sized for the longest
     // pattern (maxPatternSize), so patterns shorter than that were re-detected


### PR DESCRIPTION
Fixes #115.

## The bug

`createStream()` emitted duplicate matches at every chunk boundary. Detection was never wrong — no matches missed, none spurious — but patterns shorter than `maxPatternSize` were re-detected in the carry-over overlap and emitted twice.

Over 200,000 synthetic candles at `chunkSize: 1000` with the full 29-pattern set:

| | before | after |
|---|---|---|
| streaming emitted | 228,820 | 228,381 |
| batch `patternChain` | 228,381 | 228,381 |
| duplicates | 439 (0.192%) | 0 |

Duplicates split `{ paramCount 1: 429, paramCount 2: 10 }`, and the rate held steady at 100K, 500K and 1M candles.

## Root cause

The overlap carried between chunks is sized by the longest active pattern:

```js
const overlap = buffer.slice(chunkSize - maxPatternSize + 1);
globalOffset += chunkSize - maxPatternSize + 1;
```

With `maxPatternSize` of 3 that carries 2 candles forward — correct for three-candle formations, but shorter patterns anchored in those carried candles get scanned a second time:

| paramCount | anchors re-scanned per boundary | duplicated |
|---|---|---|
| 1 | 2 (offsets 998, 999 at chunkSize 1000) | yes |
| 2 | 1 (offset 998) | yes |
| 3 | 0 | no |

The duplicated global indices matched exactly: `998, 999, 1996, 1997, 2995, …`

## The fix

Gate emission per pattern by its own `paramCount` rather than by the shared maximum. In a non-first chunk, a pattern of size `k` anchored at local index `i` is a repeat when `i < maxPatternSize - k`. Applied in both `process()` and `end()` — the trailing buffer is an overlap region too.

## Tests

Six equivalence tests asserting streaming output matches batch `patternChain` exactly: across many boundaries, with no duplicate `(index, pattern)` pairs, over chunk sizes `[3, 4, 7, 64, 999, 1000, 1001]`, with feed size unaligned to chunk size, and on datasets that never fill a chunk.

These use a new deterministic fixture generator — the existing `generateCandles` helper uses `Math.random()`, so it cannot compare two execution modes over the same input. That gap is why the bug survived: no existing streaming test compared against `patternChain` over more than one chunk.

## Second commit: coverage

`maxPatternSize` is now derived from the `paramCount` map, and the `|| 1` fallbacks are gone. They were unreachable — the 29 built-ins all declare `paramCount`, and `plugins.registerPattern()` normalizes a missing one to 1 and validates the range (`src/pluginManager.js:33-36`), so no pattern object reaching `createStream` can lack it.

The fallback was also hiding the failure it looked like it prevented: treating a three-candle pattern as single-candle is plausible but silently wrong. Two tests now enforce the contract instead. Verified by mutation — deleting `paramCount` from `hammer` fails 4 tests with `pattern "hammer" has no numeric paramCount`.

`streaming.js` branch coverage 97.61% → **100%**; overall 99.10% → 99.23%.

## Verification

- 422 tests passing (was 414), 0 failures — Node 24.20.0
- Prettier clean; lint 0 errors (the 4 `no-console` warnings in `scripts/` are pre-existing)
- Streaming/batch equivalence re-confirmed at 200K candles after both commits

Note: `npm run coverage` fails on Node ≥ 26 — `c8`'s bundled `yargs` throws `ReferenceError: require is not defined in ES module scope`. Unrelated to this change, but it will bite when CI runners move past Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbetnffFVko1XWFJcVdbWd
