### PR TITLE
fix(streaming): reject chunkSize below the longest active pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,12 @@ boundary. Call `reset()` to reuse a stream. The `totalProcessed` in the summary 
 total number of candles you passed to `process()` — the overlap re-scanned at
 each chunk boundary is counted once, not twice.
 
+**`chunkSize` is the internal buffer threshold, not a cap on what you hand to
+`process()`** — feeding one candle at a time works at any `chunkSize`. It must be
+at least as large as the longest active pattern (3 candles for the full built-in
+set, less for a narrower `patterns` subset); smaller values throw, since the
+chunk overlap would no longer advance.
+
 **Benefits:** Reduces memory usage by ~70% for datasets > 100K candles
 
 ### Data Validation

--- a/src/streaming.js
+++ b/src/streaming.js
@@ -60,6 +60,20 @@ function createStream(options = {}) {
   );
   const maxPatternSize = Math.max(...paramCountByName.values());
 
+  // Each iteration of the process() loop consumes `chunkSize - maxPatternSize + 1`
+  // candles and carries the rest forward as overlap. That expression must be
+  // positive: at zero the overlap is the whole buffer and the loop never
+  // terminates, and below zero `buffer.slice()` counts from the end, dropping
+  // unscanned candles and driving `globalOffset` negative. The threshold depends
+  // on the active pattern set, so it is checked here rather than next to the
+  // integer check above.
+  if (chunkSize < maxPatternSize) {
+    throw new Error(
+      `chunkSize must be at least ${maxPatternSize} for the selected patterns ` +
+        `(the longest takes ${maxPatternSize} candles), got: ${chunkSize}`,
+    );
+  }
+
   /**
    * The carry-over overlap is sized for the longest pattern (`maxPatternSize`),
    * so shorter patterns anchored at the start of a non-first chunk were already

--- a/test/streaming.test.js
+++ b/test/streaming.test.js
@@ -465,6 +465,123 @@ describe("Streaming API", () => {
       assert.doesNotThrow(() => stream.process(chunk));
     });
   });
+  describe("chunkSize lower bound", () => {
+    // Regression for #117: the process() loop consumes
+    // `chunkSize - maxPatternSize + 1` candles per iteration. At zero the
+    // overlap is the whole buffer and the loop never terminates; below zero
+    // buffer.slice() counts from the end, dropping unscanned candles and
+    // driving globalOffset negative. Both were silent — only chunkSize < 1 and
+    // non-integers were rejected.
+    const maxPatternSize = Math.max(...allPatterns.map((p) => p.paramCount));
+
+    function keysFor(data, patternNames, chunkSize) {
+      const keys = [];
+      const stream = createStream({
+        patterns: patternNames,
+        chunkSize,
+        onMatch: (r) => keys.push(`${r.index}|${r.pattern}`),
+      });
+      for (const candle of data) stream.process([candle]);
+      stream.end();
+      return keys.sort();
+    }
+
+    function batchKeysFor(data, patternNames) {
+      const fns = allPatterns.filter((p) => patternNames.includes(p.name));
+      return patternChain(data, fns)
+        .map((r) => `${r.index}|${r.pattern}`)
+        .sort();
+    }
+
+    it("throws at maxPatternSize - 1, the value that used to hang", () => {
+      // Guards the infinite loop: overlap === buffer.slice(0) === the whole
+      // buffer, so the while condition stays true forever. A failure here does
+      // not assert — it hangs the suite.
+      assert.throws(
+        () => createStream({ chunkSize: maxPatternSize - 1 }),
+        new RegExp(`chunkSize must be at least ${maxPatternSize}`),
+      );
+    });
+
+    it("throws below maxPatternSize - 1, where output used to be corrupt", () => {
+      assert.throws(
+        () => createStream({ chunkSize: 1 }),
+        new RegExp(`chunkSize must be at least ${maxPatternSize}`),
+      );
+    });
+
+    it("names the offending value and the required minimum", () => {
+      assert.throws(() => createStream({ chunkSize: 2 }), {
+        message: `chunkSize must be at least 3 for the selected patterns (the longest takes 3 candles), got: 2`,
+      });
+    });
+
+    it("accepts exactly maxPatternSize and matches batch output", () => {
+      const data = generateDeterministicCandles(300);
+      const names = allPatterns.map((p) => p.name);
+      assert.deepEqual(
+        keysFor(data, names, maxPatternSize),
+        batchKeysFor(data, names),
+      );
+    });
+
+    it("keeps the non-integer and < 1 checks ahead of the new bound", () => {
+      // The integer check runs before patterns are resolved, so its message
+      // must still win for values that fail both.
+      assert.throws(
+        () => createStream({ chunkSize: 0 }),
+        /chunkSize must be a positive integer/,
+      );
+      assert.throws(
+        () => createStream({ chunkSize: 2.5 }),
+        /chunkSize must be a positive integer/,
+      );
+    });
+
+    describe("the bound follows the active pattern set", () => {
+      it("allows chunkSize 1 for a paramCount-1 pattern", () => {
+        const data = generateDeterministicCandles(200);
+        assert.doesNotThrow(() =>
+          createStream({ patterns: ["doji"], chunkSize: 1 }),
+        );
+        assert.deepEqual(
+          keysFor(data, ["doji"], 1),
+          batchKeysFor(data, ["doji"]),
+        );
+      });
+
+      it("requires chunkSize 2 for a paramCount-2 pattern", () => {
+        const data = generateDeterministicCandles(200);
+        assert.throws(
+          () => createStream({ patterns: ["bullishEngulfing"], chunkSize: 1 }),
+          /chunkSize must be at least 2 for the selected patterns/,
+        );
+        assert.deepEqual(
+          keysFor(data, ["bullishEngulfing"], 2),
+          batchKeysFor(data, ["bullishEngulfing"]),
+        );
+      });
+
+      it("takes the longest pattern when the subset is mixed", () => {
+        assert.throws(
+          () =>
+            createStream({
+              patterns: ["doji", "bullishEngulfing"],
+              chunkSize: 1,
+            }),
+          /chunkSize must be at least 2 for the selected patterns/,
+        );
+      });
+    });
+
+    it("processLargeDataset surfaces the same error", () => {
+      assert.throws(
+        () => processLargeDataset(generateCandles(50), { chunkSize: 1 }),
+        new RegExp(`chunkSize must be at least ${maxPatternSize}`),
+      );
+    });
+  });
+
   describe("pattern size invariant", () => {
     // The chunk-overlap math in createStream indexes paramCount directly.
     // If a pattern ever shipped without it, maxPatternSize would become NaN

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -671,6 +671,12 @@ export const metadata: {
  */
 export interface StreamOptions {
   patterns?: string[] | string | null;
+  /**
+   * Internal buffer threshold, not a limit on how much you may hand to
+   * `process()` — feeding one candle at a time is fine at any `chunkSize`.
+   * Must be at least the `paramCount` of the longest active pattern (3 for the
+   * full built-in set); smaller values throw.
+   */
   chunkSize?: number;
   onMatch?: (match: PatternMatch) => void;
   onProgress?: (progress: {


### PR DESCRIPTION
Fixes #117.

## The bug

`process()` consumes `chunkSize - maxPatternSize + 1` candles per iteration and carries the rest forward as overlap. That expression was assumed positive and never validated — `createStream()` only rejected non-integers and values below 1.

| condition | failure |
|---|---|
| `chunkSize === maxPatternSize - 1` | argument is `0` → `overlap` is the whole buffer, the buffer never shrinks, the `while` loop never terminates. `process()` hangs until the heap is exhausted. |
| `chunkSize < maxPatternSize - 1` | argument is negative → `buffer.slice()` counts from the end, discarding candles that are never scanned, and `globalOffset` is decremented each iteration, producing negative match indices. |

Reproduced against `main` (full pattern set, `maxPatternSize` 3): `chunkSize: 2` hangs and OOMs on 20 candles; `chunkSize: 1` reported `totalProcessed: 0` for 20 candles fed.

## The fix

One guard, placed where `maxPatternSize` is known — after the pattern set is resolved — so the bound follows the active patterns rather than being hardcoded:

```js
if (chunkSize < maxPatternSize) {
  throw new Error(
    `chunkSize must be at least ${maxPatternSize} for the selected patterns ` +
      `(the longest takes ${maxPatternSize} candles), got: ${chunkSize}`,
  );
}
```

Nothing that works today starts failing: `chunkSize: 1` remains legal for a `paramCount`-1 pattern such as `doji`, and is rejected for the full built-in set, exactly as the failure table in #117 requires.

Throwing rather than clamping is deliberate. A caller passing `chunkSize: 1` has the wrong mental model of the option — it is the internal buffer threshold, not a limit on what `process()` accepts — and clamping would hide that while silently changing their memory profile. As #117 notes, the genuine tick-by-tick case is already served: feeding one candle at a time works at any valid `chunkSize`. README and `StreamOptions` now state both points.

## Tests

Nine tests under `chunkSize lower bound`:

- throws at `maxPatternSize - 1` (the hang) and below it (the corruption) — the first would hang the suite rather than assert if the guard regressed
- exact error message, naming the offending value and the required minimum
- `chunkSize === maxPatternSize` accepted, output identical to `patternChain` over 300 candles
- the existing non-integer / `< 1` messages still win, since that check runs before the pattern set is resolved
- bound follows the active set: `doji` at 1 accepted and equivalent to batch; `bullishEngulfing` rejected at 1, equivalent to batch at 2; a mixed subset takes the longest pattern
- `processLargeDataset` surfaces the same error

## Verification

- 443 tests passing, 0 failures
- `src/streaming.js` coverage **100%** statements / branches / functions / lines
- 200 randomized differential runs (1–900 candles, `chunkSize` 3–62, feed size 1–120, full pattern set): output identical to `patternChain`, `totalProcessed` exact, no duplicates — 0 bad runs
- Lint 0 errors (4 pre-existing `no-console` warnings in `scripts/`), Prettier clean
- `examples/streaming.js` runs unchanged

## Note for the release

This is a behavioral change — a previously accepted argument now throws — so it belongs in the same minor bump as #120 rather than a patch.

Out of scope, found while writing these tests: `createStream()` resolves patterns only against the static `allPatterns` export, so patterns registered through `plugins.registerPattern()` are not reachable from the streaming API at all (`No matching patterns found`). Unrelated to this fix; worth its own issue if it should be supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
