### PR TITLE
ci: test on Node 24.x and document the supported matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,13 @@ Thank you for your interest in contributing! Your help is welcome and appreciate
 - Ensure TypeScript definitions are updated for new functions (types/index.d.ts).
 - Write tests for all new features (target 99%+ line coverage and 100% function coverage).
 
+## Supported Node.js Versions
+
+The package requires Node.js >= 20 (`package.json#engines`). CI runs the full
+suite on **20.x, 22.x and 24.x** across Linux, Windows and macOS, so a change
+must pass on all three before it can merge. Develop on a version inside that
+range; anything that only works on a newer runtime will fail the 20.x jobs.
+
 ## Running Tests
 
 - Run all tests with:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A modern, modular JavaScript library for [candlestick pattern](https://en.wikipe
 - ✅ Comprehensive test suite with high coverage (run `npm test` and `npm run coverage`)
 - 🪶 Zero runtime dependencies
 
-> **Requires Node.js >= 20**
+> **Requires Node.js >= 20.** Tested in CI on Node 20.x, 22.x and 24.x across Linux, Windows and macOS.
 
 ---
 


### PR DESCRIPTION
## Why

Node 24 is the current LTS (krypton) and is what `nvm install --lts` gives a contributor today, but the CI matrix stopped at 22.x. Nothing verified the package on the runtime most people are actually using before a release went out.

## Changes

**CI** — `.github/workflows/node.js.yml` matrix goes from `[20.x, 22.x]` to `[20.x, 22.x, 24.x]`, giving 9 jobs across ubuntu / windows / macOS. Each runs the existing steps unchanged: `npm ci`, lint, build, test, coverage, Coveralls upload.

**Docs** — the tested range is now stated where a reader looks for it:

- `README.md` — the requirement line becomes "**Requires Node.js >= 20.** Tested in CI on Node 20.x, 22.x and 24.x across Linux, Windows and macOS."
- `CONTRIBUTING.md` — a new **Supported Node.js Versions** section giving the `engines` floor, the CI matrix, and the reason to develop inside the range rather than above it: code that only works on a newer runtime fails the 20.x jobs.

## Deliberately unchanged

- **`.github/workflows/benchmark.yml` stays on 22.x.** Its results are tracked over time by `github-action-benchmark`; switching the runtime would break the continuity of that baseline and make every subsequent comparison a false signal. Worth doing as its own change, with the baseline reset explicitly.
- **The publish workflows stay on 20**, so releases are built on the floor declared by `engines`.
- **`docs/ROADMAP.md` release entries** record the matrix as it was at each release. Editing them would rewrite history rather than document the present.
- **`.nvmrc` is untouched.** It pins 18, which contradicts `engines: ">=20"` and the README — tracked separately in #123, since choosing the replacement value is a decision in its own right.

## Verification

Locally on **v24.21.0** (npm 11.19.0):

- `npm run lint` — 0 errors (4 pre-existing `no-console` warnings in `scripts/`)
- `npm test` — **443 passing, 0 failures**
- `npm run coverage` — 99.82% overall, `streaming.js` **100%**
- `npm run bench` — completes; streaming section clean
- All **15 examples** run successfully; CLI smoke-tested against `cli/test-data.json`
- Workflow YAML parsed and asserted to yield the expected 3 × 3 matrix
- Prettier clean on all three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
