### PR TITLE
fix(benchmark): separate feed size from chunkSize in the streaming benchmark

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -215,31 +215,68 @@ console.log("=".repeat(60));
 
 const { createStream } = require("./src/streaming.js");
 
-function runStreamBenchmark(label, totalCandles, chunkSize) {
+// Two independent axes, previously conflated (#118):
+//   feedSize  - how many candles are handed to process() per call
+//   chunkSize - the stream's internal buffer threshold
+// Varying the first says nothing about the second, so each row states both.
+const STREAM_PATTERNS = ["hammer", "doji"];
+const streamPatternFns = allPatterns.filter((p) =>
+  STREAM_PATTERNS.includes(p.name),
+);
+// chunkSize must be at least the longest active pattern (#117), so the sweep
+// is clamped rather than silently throwing partway through a run.
+const MIN_CHUNK_SIZE = Math.max(...streamPatternFns.map((p) => p.paramCount));
+
+function runStreamBenchmark(totalCandles, feedSize, chunkSize) {
+  if (chunkSize < MIN_CHUNK_SIZE) {
+    throw new Error(
+      `benchmark misconfigured: chunkSize ${chunkSize} is below the minimum ` +
+        `${MIN_CHUNK_SIZE} for patterns ${STREAM_PATTERNS.join(", ")}`,
+    );
+  }
+
   const data = generateCandles(totalCandles);
   const chunks = [];
-  for (let i = 0; i < data.length; i += chunkSize) {
-    chunks.push(data.slice(i, i + chunkSize));
+  for (let i = 0; i < data.length; i += feedSize) {
+    chunks.push(data.slice(i, i + feedSize));
   }
 
   const start = performance.now();
-  const stream = createStream({
-    patterns: ["hammer", "doji"],
-    chunkSize: 1000,
-  });
+  const stream = createStream({ patterns: STREAM_PATTERNS, chunkSize });
   for (const chunk of chunks) stream.process(chunk);
-  stream.end();
+  const summary = stream.end();
   const elapsed = performance.now() - start;
 
+  // Cheap correctness guard: a run that silently dropped candles is not a
+  // measurement worth reporting.
+  if (summary.totalProcessed !== totalCandles) {
+    throw new Error(
+      `benchmark processed ${summary.totalProcessed} of ${totalCandles} candles ` +
+        `(feed=${feedSize}, chunkSize=${chunkSize})`,
+    );
+  }
+
   console.log(
-    `  ${label}: ${totalCandles.toLocaleString()} candles, chunks of ${chunkSize} → ${elapsed.toFixed(2)} ms (${((totalCandles / elapsed) * 1000).toFixed(0)} candles/sec)`,
+    `  ${totalCandles.toLocaleString().padStart(9)} candles | feed ${String(feedSize).padStart(5)} | chunkSize ${String(chunkSize).padStart(5)} → ${elapsed.toFixed(2).padStart(8)} ms (${((totalCandles / elapsed) * 1000).toFixed(0).padStart(9)} candles/sec)`,
   );
 }
 
-console.log("\nBatch mode (large chunks):");
-runStreamBenchmark("10k  / chunk=500 ", 10_000, 500);
-runStreamBenchmark("100k / chunk=1000", 100_000, 1000);
+console.log(
+  `\nMeasuring ${streamPatternFns.length} of ${allPatterns.length} patterns ` +
+    `(${STREAM_PATTERNS.join(", ")} — both single-candle), so these figures are` +
+    `\nnot representative of the streaming API over the full pattern set.`,
+);
 
-console.log("\nTick-by-tick mode (chunk=1):");
-runStreamBenchmark("1k ticks ", 1_000, 1);
-runStreamBenchmark("10k ticks", 10_000, 1);
+console.log(
+  "\nFeed size (candles per process() call), chunkSize fixed at 1000:",
+);
+runStreamBenchmark(100_000, 1, 1000);
+runStreamBenchmark(100_000, 500, 1000);
+runStreamBenchmark(100_000, 1000, 1000);
+runStreamBenchmark(100_000, 10_000, 1000);
+
+console.log("\nchunkSize (internal buffer threshold), feed fixed at 1000:");
+runStreamBenchmark(100_000, 1000, MIN_CHUNK_SIZE);
+runStreamBenchmark(100_000, 1000, 100);
+runStreamBenchmark(100_000, 1000, 1000);
+runStreamBenchmark(100_000, 1000, 10_000);


### PR DESCRIPTION
Fixes #118.

## The bug

`runStreamBenchmark(label, totalCandles, chunkSize)` accepted a `chunkSize`, used it only to slice the input feed, then hardcoded `chunkSize: 1000` on the stream it measured:

```js
for (let i = 0; i < data.length; i += chunkSize) chunks.push(...); // parameter used here
const stream = createStream({ patterns: [...], chunkSize: 1000 }); // parameter ignored
```

So all four rows measured the same stream configuration while their labels advertised different chunk sizes. They also used different dataset sizes, which is what produced the inversion #118 reports — "Tick-by-tick" reading as faster than "batch mode, chunks of 500" was small-input variance between rows measuring the same thing.

## The fix

`feedSize` (candles per `process()` call) and `chunkSize` (internal buffer threshold) are independent axes, so the benchmark now treats them as such: both are parameters, `chunkSize` reaches `createStream`, and every row prints both. All rows use the same 100,000 candles so they are directly comparable, and each axis gets a sweep with the other held fixed.

The `chunkSize` sweep measures something the old benchmark structurally could not:

```
Feed size (candles per process() call), chunkSize fixed at 1000:
    100,000 candles | feed     1 | chunkSize  1000 →    43.11 ms (  2319765 candles/sec)
    100,000 candles | feed   500 | chunkSize  1000 →    27.48 ms (  3638450 candles/sec)
    100,000 candles | feed  1000 | chunkSize  1000 →    30.61 ms (  3267008 candles/sec)
    100,000 candles | feed 10000 | chunkSize  1000 →    29.40 ms (  3401490 candles/sec)

chunkSize (internal buffer threshold), feed fixed at 1000:
    100,000 candles | feed  1000 | chunkSize     1 →   114.48 ms (   873516 candles/sec)
    100,000 candles | feed  1000 | chunkSize   100 →    27.35 ms (  3656427 candles/sec)
    100,000 candles | feed  1000 | chunkSize  1000 →    26.04 ms (  3840343 candles/sec)
    100,000 candles | feed  1000 | chunkSize 10000 →    27.36 ms (  3655409 candles/sec)
```

`chunkSize: 1` is ~4x slower than 100 or above; feed size barely matters past 500. Neither was visible before.

Two guards added:

- The sweep computes the minimum legal `chunkSize` from the active pattern set and refuses anything below it up front, rather than throwing partway through a run — this is the #117 coupling flagged when that fix landed.
- A run whose `totalProcessed` does not equal the candles fed throws instead of printing throughput for a stream that silently dropped data.

The secondary observation in #118 is addressed too: the section now states it measures 2 of 29 patterns, both single-candle, so the numbers are not read as representative of the full set.

## Compatibility

Console output only. The `--json` `entries` consumed by `github-action-benchmark` come from the `patternChain` / `Hammer` / `Memory` results and are **byte-identical** — verified by diffing the emitted entry names and the `table` rows. The tracked baseline keeps its continuity, so this cannot produce a false regression alert.

`scripts/update-bench.js` (`npm run bench:readme`) reads only the `table` field and is unaffected; the README benchmark table is deliberately left untouched rather than overwritten with numbers from my machine.

## Verification

On Node v24.21.0: `npm run bench` completes and both sweeps run; 443 tests passing; lint 0 errors (4 pre-existing `no-console` warnings in `scripts/`); Prettier clean; `--json` output schema confirmed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
