### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A modern, modular JavaScript library for [candlestick pattern](https://en.wikipe
 - [Development](#development)
 - [Architecture](#architecture)
 - [Contributing](#contributing)
+- [Upgrading to v2.1](#upgrading-to-v21)
 - [Upgrading from v1.x](#upgrading-from-v1x)
 - [FAQ](#faq)
 - [Changelog](#changelog)
@@ -602,6 +603,36 @@ See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for an overview of the librar
 5. Write tests in `test/myPattern.test.js` covering valid matches, non-matches, and edge cases
 6. Add an example file in `examples/myPattern.js`
 7. Run `npm test && npm run lint` to verify
+
+---
+
+## Upgrading to v2.1
+
+v2.1.0 fixes three streaming defects. The fixes are behavioural, so code that
+relied on the broken behaviour will see a difference:
+
+1. **`totalProcessed` no longer double-counts the chunk overlap.** The summary
+   from `end()` now equals the exact number of candles passed to `process()`.
+   Previously it was inflated by `maxPatternSize - 1` per chunk boundary. If you
+   assert on this value, update the expected number.
+
+2. **`end()` is idempotent, and `process()` after `end()` throws.** Repeat
+   `end()` calls return the same summary without re-emitting matches or firing
+   `onProgress({ complete: true })` again. Draining the buffer means a later
+   `process()` would resume without the carry-over candles and silently miss
+   patterns spanning that boundary, so it raises
+   `Cannot process() after end(); call reset() to reuse this stream`. Call
+   `reset()` to reuse a stream.
+
+3. **`chunkSize` below the longest active pattern is rejected.** Such values
+   previously hung `process()` in an infinite loop or silently dropped candles
+   and produced negative indices. `chunkSize` is the internal buffer threshold,
+   not a limit on what you hand to `process()` — feeding one candle at a time
+   works at any valid `chunkSize`, so the usual fix is to remove the option and
+   take the default.
+
+Nothing changes for streams using the default `chunkSize` that call `end()`
+once, and no API signatures changed.
 
 ---
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -5,10 +5,17 @@ const fs = require("fs");
 const path = require("path");
 const candlestick = require("../index.js");
 
+const { version } = require("../package.json");
+const BANNER_TITLE = `Candlestick Pattern Detection CLI v${version}`;
+const BANNER_WIDTH = 62;
+const BANNER_PAD = Math.max(0, BANNER_WIDTH - BANNER_TITLE.length);
+const BANNER_LEFT = " ".repeat(Math.floor(BANNER_PAD / 2));
+const BANNER_RIGHT = " ".repeat(Math.ceil(BANNER_PAD / 2));
+
 const HELP_TEXT = `
-╔══════════════════════════════════════════════════════════════╗
-║          Candlestick Pattern Detection CLI v2.0.2            ║
-╚══════════════════════════════════════════════════════════════╝
+╔${"═".repeat(BANNER_WIDTH)}╗
+║${BANNER_LEFT}${BANNER_TITLE}${BANNER_RIGHT}║
+╚${"═".repeat(BANNER_WIDTH)}╝
 
 Usage: candlestick [options]
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,6 +27,18 @@ This roadmap outlines planned features and future directions for the Candlestick
 
 ## Completed
 
+### v2.1.0 (2026-09-11)
+
+Streaming correctness release. Three changes are observable through the public
+API — see "Upgrading to v2.1" in the README before updating.
+
+- fix(streaming): drop duplicate matches at chunk boundaries for patterns shorter than `maxPatternSize` ([#115](https://github.com/cm45t3r/candlestick/issues/115))
+- fix(streaming): make `end()` idempotent and count `totalProcessed` exactly ([#119](https://github.com/cm45t3r/candlestick/issues/119))
+- fix(streaming): reject `chunkSize` below the longest active pattern, which previously hung or silently corrupted output ([#117](https://github.com/cm45t3r/candlestick/issues/117))
+- fix(benchmark): separate feed size from `chunkSize` in the streaming benchmark ([#118](https://github.com/cm45t3r/candlestick/issues/118))
+- fix(cli): derive the banner version from `package.json` instead of hardcoding it
+- ci: test on Node 24.x; CI matrix is now 20.x / 22.x / 24.x across Linux, Windows and macOS
+
 ### v2.0.2 (2026-07-10)
 
 - chore(deps): bump `prettier` from 3.8.4 to 3.9.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "candlestick",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "candlestick",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "bin": {
         "candlestick": "bin/candlestick"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "candlestick",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "JavaScript library for candlestick patterns detection.",
   "homepage": "https://github.com/cm45t3r/candlestick",
   "author": {


### PR DESCRIPTION
Version bump to **2.1.0**. Minor, not patch: three of the fixes merged since 2.0.2 are observable through the public API.

## What's in the release

| | |
|---|---|
| #115 / #116 | duplicate matches emitted at chunk boundaries for patterns shorter than `maxPatternSize` |
| #119 / #120 | `end()` not idempotent; `totalProcessed` double-counted the overlap |
| #117 / #122 | `chunkSize` below the longest active pattern hung `process()` or silently corrupted output |
| #118 / #125 | streaming benchmark measured feed size while advertising `chunkSize` |
| #124 | CI extended to Node 24.x |

## Why minor and not patch

Three behaviours changed for callers:

1. `end().totalProcessed` returns a different (correct) number for any stream with more than one chunk boundary.
2. `end()` is idempotent, and `process()` after `end()` now throws.
3. `chunkSize` below the longest active pattern now throws.

Each is documented with its migration in a new **Upgrading to v2.1** section in the README, linked from the table of contents. Nothing changes for streams that use the default `chunkSize` and call `end()` once, and no API signatures changed.

Strictly, #117 and the `process()`-after-`end()` throw reject inputs that were previously accepted — the purist reading is a major. I've treated them as minor because neither ever produced correct results: one hung or corrupted output, the other re-emitted duplicate matches. Say the word if you'd rather cut 3.0.0.

## Also included

`cli/index.js` was still printing `v2.0.2` in its banner, having drifted since the last bump. It now derives the version from `package.json`, with the box padded to a fixed width so a longer version string can't break the border. Verified: `--help` prints `v2.1.0`.

## Deliberately untouched

`CHANGELOG.md` — `.github/workflows/release.yml` regenerates it from merged PRs on tag push and commits it back to `main`. Hand-writing an entry here would just be overwritten. (Its pre-existing Prettier warning is from that generator and unrelated to this PR.)

## Verification

On Node v24.21.0: 443 tests passing, coverage 99.82% overall, lint 0 errors, all 15 examples run, CLI smoke-tested, `npm pack --dry-run` produces `candlestick-2.1.0.tgz` at 40.7 kB with the expected file list.

## Release is not triggered by this PR

Merging only lands the version bump. Pushing the `v2.1.0` tag is what fires `release.yml` → GitHub Release → `npm-publish.yml` → **publish to npm**, which is irreversible. I have not created or pushed any tag; that step is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
