### PR TITLE
ci: publish on tag push instead of release creation

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,11 +1,21 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# Publishes the package to GitHub Packages when a v*.*.* tag is pushed.
+#
+# Same trigger fix as npm-publish.yml: the release is created with
+# secrets.GITHUB_TOKEN, and GitHub does not start workflow runs from events
+# raised by that token, so `on: release` never fired.
 
 name: Publish to GitHub Packages
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish, e.g. v2.1.0"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -13,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -29,6 +41,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,11 +1,22 @@
-# This workflow will run tests using node and then publish a package to npm when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# Publishes the package to npm when a v*.*.* tag is pushed.
+#
+# The trigger is the tag, not the GitHub Release. Release Automation creates
+# the release with secrets.GITHUB_TOKEN, and GitHub does not start new workflow
+# runs from events raised by that token, so an `on: release` trigger never
+# fired — every version on npm so far was published by hand.
 
 name: Publish to npm
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish, e.g. v2.1.0"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -13,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -24,15 +37,31 @@ jobs:
     name: Publish to npm
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required by `npm publish --provenance`, which mints a signed
+      # attestation from an OIDC token. Without it the publish fails.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          PKG="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::tag $TAG does not match package.json version $PKG"
+            exit 1
+          fi
+          echo "publishing $PKG"
       - run: npm ci
       - run: npm run lint
       - run: npm test
       - run: npm publish --provenance
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## The evidence

Neither publish workflow has ever run — not once, for any of the six GitHub Releases:

```
$ gh run list --workflow=25211128   # Publish to npm
(no runs)
$ gh run list --workflow=25390788   # Publish to GitHub Packages
(no runs)
```

Meanwhile npm shows `2.0.2` published at `2026-07-10T07:08:46Z`, six minutes after its release was created at `07:02:41Z`. Every version on npm was published by hand from a laptop.

## Root cause

`release.yml` creates the release with `actions/create-release@v1` authenticated as `secrets.GITHUB_TOKEN`. GitHub does not start new workflow runs from events raised by that token — the built-in recursion guard. So `on: release: types: [created]` could never fire from the automated release. It would only have fired for a release created manually in the UI or with a PAT.

**A second failure was queued behind it.** `npm publish --provenance` mints a signed attestation from an OIDC token and requires `id-token: write`; the job declared no `permissions:` block at all. Fixing only the trigger would have converted a silent no-op into a failing publish.

## The fix

Trigger on the **tag push** — the same event `release.yml` already runs on successfully, and one a human-pushed tag raises normally, so no PAT and no new secret:

```yaml
on:
  push:
    tags: ["v*.*.*"]
  workflow_dispatch:
    inputs:
      tag: { description: "Tag to publish, e.g. v2.1.0", required: true, type: string }
```

Plus:

- **`permissions: { contents: read, id-token: write }`** on the publish job, so `--provenance` can actually mint its attestation.
- **`workflow_dispatch`** with a tag input, so a failed publish can be retried without cutting a new tag. Every checkout resolves `ref: ${{ inputs.tag || github.ref }}`, so both entry points build the same commit.
- **A tag/version guard** that fails before publishing if the tag doesn't match `package.json#version`:

  ```
  v2.1.0 -> would publish v2.1.0
  v2.0.9 -> would FAIL (pkg v2.1.0)
  ```

`npm-publish-github-packages.yml` had the identical trigger bug and gets the same treatment; it already declared `packages: write`, so it needed only the trigger and the checkout ref.

## Notes

- Both publish workflows now run in parallel with `release.yml` on the same tag. They don't depend on the release existing, so ordering doesn't matter. One consequence worth knowing: the tarball carries the `CHANGELOG.md` as of the tag, not the one `release.yml` regenerates and commits to `main` afterwards — that was already true and is unchanged here.
- **`NPM_TOKEN` has never been exercised by CI.** If the first tagged publish fails on auth, that's the reason; it needs to be a current automation token.

## Verification

YAML parsed and asserted for both files: triggers `push` + `workflow_dispatch`, jobs intact, `publish-npm` carrying `{contents: read, id-token: write}` and `publish-gpr` `{contents: read, packages: write}`. Guard logic exercised locally against a matching and a mismatched tag. Lint 0 errors, 443 tests passing, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
