### PR TITLE
fix(scripts): run the benchmark without a shell in update-bench

### DIFF
--- a/scripts/update-bench.js
+++ b/scripts/update-bench.js
@@ -4,7 +4,7 @@
    Usage: node scripts/update-bench.js            (run bench + update)
           node scripts/update-bench.js results.json (use existing JSON) */
 
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
@@ -19,7 +19,12 @@ if (existingJson) {
   updateReadme(data.table || data);
 } else {
   console.log("Running benchmark suite...\n");
-  execSync(`node benchmark.js --json ${tmpJson}`, {
+  // execFileSync, not execSync: tmpJson is an absolute path derived from
+  // __dirname, so interpolating it into a shell string breaks on a checkout
+  // directory containing a space and would execute anything a directory name
+  // smuggled in. Passing argv directly runs no shell at all. process.execPath
+  // also keeps the child on the same Node binary as the parent.
+  execFileSync(process.execPath, ["benchmark.js", "--json", tmpJson], {
     cwd: root,
     stdio: "inherit",
   });


### PR DESCRIPTION
Closes CodeQL alert #2 — `js/shell-command-injection-from-environment`, medium, open since 2026-07-11 and the only open security alert on the repo (no Dependabot alerts).

## The finding

`scripts/update-bench.js:22` built its command as a shell string:

```js
execSync(`node benchmark.js --json ${tmpJson}`, { cwd: root, stdio: "inherit" });
```

`tmpJson` is `path.join(root, "bench-results.json")` where `root` derives from `__dirname` — an absolute path this script does not control.

## Is it real?

The honest severity is **low in practice, real as a bug**. Nothing attacker-controlled reaches that string in normal use: the path is wherever the repo was checked out, and the script is a dev tool that never runs in CI.

But the quoting defect fires today, without any attacker. Demonstrated in a directory whose name contains a space:

```
execSync:     FAILED -> Error: Cannot find module '.../scratchpad/dir'
execFileSync: argv: ["--json", ".../dir with space/bench-results.json"]
```

The shell splits the path at the space and the run fails. A directory name containing shell metacharacters would be *executed* rather than passed — which is exactly the class CodeQL is flagging. "Nobody puts a space in a checkout path" is not a property this repo can enforce; plenty of people clone under `~/My Projects/`.

## The fix

```js
execFileSync(process.execPath, ["benchmark.js", "--json", tmpJson], {
  cwd: root,
  stdio: "inherit",
});
```

`execFileSync` with an argv array spawns no shell, so the path arrives intact whatever it contains — the quoting bug and the injection class both disappear rather than being papered over with quotes. `process.execPath` additionally keeps the child on the same Node binary as the parent, instead of whichever `node` the `PATH` happens to resolve to.

This is the only shell invocation in the repository — `grep` for `execSync|exec(|spawn` outside `node_modules` returns these two lines and nothing else.

## Verification

- `npm run bench:readme` produces the same README table as before (README left unmodified in this PR)
- Reproduced the failure and the fix side by side in a path containing a space
- 443 tests passing, lint 0 errors, Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
