### PR TITLE
ci: run CodeQL on main, not the non-existent master branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: "21 0 * * 6"
 


### PR DESCRIPTION
## The bug

`codeql-analysis.yml` triggers on `master`:

```yaml
on:
  push:
    branches: [master]
  pull_request:
    branches: [master]
```

This repository has no `master` branch — `git ls-remote --heads origin` returns `main`, `gh-pages` and one feature branch. Neither trigger has ever matched.

## Impact

CodeQL has only ever run from its weekly cron (`21 0 * * 6`). Two consequences:

1. **No pull request in this repository has ever been analysed before merge.** Security analysis is entirely post-hoc, and a finding introduced on a Monday sits undetected until Saturday.
2. **Fixes take just as long to register.** The shell-injection fix in #128 merged today, but alert #2 stays open until the next scheduled scan, because nothing re-analyses `main` on push.

Same shape as the publish-workflow bug in #127: a workflow wired to an event that never fires, silently doing nothing for as long as anyone cares to look back. The last three runs are all `schedule`.

## The fix

Point both triggers at `main`. The weekly cron stays as a backstop for anything that lands outside a pull request.

## Verification

YAML parsed: `push: {branches: [main]}`, `pull_request: {branches: [main]}`, cron unchanged. Prettier clean.

This PR is itself the test — if the trigger now works, a **CodeQL** check appears on it, which has never happened on a pull request in this repository before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
