### PR TITLE
chore: silence no-console in update-bench like its peers

### DIFF
--- a/scripts/update-bench.js
+++ b/scripts/update-bench.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-console */
+
 /* Runs the benchmark suite and updates the performance table in README.md.
    Usage: node scripts/update-bench.js            (run bench + update)
           node scripts/update-bench.js results.json (use existing JSON) */


### PR DESCRIPTION
`npm run lint` reported 4 warnings — all `no-console` in `scripts/update-bench.js`, and nothing else in the repository:

```
/scripts/update-bench.js
  21:3  warning  Unexpected console statement  no-console
  56:5  warning  Unexpected console statement  no-console
  79:3  warning  Unexpected console statement  no-console
  80:3  warning  Unexpected console statement  no-console

✖ 4 problems (0 errors, 4 warnings)
```

## Why only that file

`no-console` is `"warn"` globally in `eslint.config.js` and switched off only for `**/*.mjs`. Every other console-heavy CommonJS file carries a file-level pragma:

- `benchmark.js:1` — `/* eslint-disable no-console */`
- `cli/index.js:2` — same
- `examples/streaming.js:1` — same

`scripts/update-bench.js` is the only one that never got it. So this is a missing pragma, not a code smell: the console output *is* the script's product — it prints the regenerated table for the operator to read — which is why suppressing beats rewriting the calls.

## Result

```
$ npm run lint
> eslint .
lint exit=0
```

Zero problems. The point is not tidiness: a warning list that always has four entries is one nobody reads, so a real warning introduced later would arrive camouflaged. Now any output at all means something new.

## Verification

443 tests passing, Prettier clean, and `npm run bench:readme` still regenerates the README table correctly (README left unmodified here).

## Related

Two documentation issues found in the same clean-room pass, filed separately: #135 (streaming example contradicts the ~70% memory claim) and #136 (README benchmark table is stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
