### PR TITLE
docs(streaming): measure the memory claim honestly in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A modern, modular JavaScript library for [candlestick pattern](https://en.wikipe
 
 - 📊 18 candlestick patterns, 29 variants across single, two, and three-candle formations
 - 📦 ESM & CommonJS dual export with full TypeScript definitions
-- 🌊 Streaming API for massive datasets (~70% memory reduction)
+- 🌊 Streaming API for massive datasets (resident memory bounded by `chunkSize`, not dataset size)
 - 🔌 Plugin system for custom patterns, data validation, pattern metadata
 - ✅ Comprehensive test suite with high coverage (run `npm test` and `npm run coverage`)
 - 🪶 Zero runtime dependencies
@@ -435,7 +435,23 @@ at least as large as the longest active pattern (3 candles for the full built-in
 set, less for a narrower `patterns` subset); smaller values throw, since the
 chunk overlap would no longer advance.
 
-**Benefits:** Reduces memory usage by ~70% for datasets > 100K candles
+**Benefits:** Resident memory stays bounded by `chunkSize` instead of scaling
+with the dataset. Measured on 200,000 candles with five patterns: 41.9 MB live
+heap for `patternChain` against 0.2 MB for the stream — the same 61,866 matches
+in both cases.
+
+Two conditions are doing the work, and both are easy to lose:
+
+- **Consume matches in `onMatch` rather than collecting them.** Pushing every
+  match into an array puts the result set back in memory, and at high match
+  counts it dominates whatever the buffering saved.
+- **Feed the stream incrementally.** Passing `process()` slices of an array you
+  already built keeps that array resident, so there is nothing left to save.
+  `processLargeDataset` is a convenience wrapper and does both of these, so it
+  trades the memory benefit for a simpler call.
+
+See `examples/streaming.js`, which measures this and prints the comparison; run
+it with `node --expose-gc` for stable figures.
 
 ### Data Validation
 

--- a/examples/streaming.js
+++ b/examples/streaming.js
@@ -107,38 +107,120 @@ Object.entries(byPattern)
   });
 
 // Example 3: Memory comparison
+//
+// The saving comes from never holding the whole dataset resident, so a fair
+// demonstration has to:
+//   (a) exceed the 100K candles the README scopes the claim to;
+//   (b) generate the streaming input chunk by chunk — an array you build up
+//       front is resident whether or not you stream it;
+//   (c) count matches instead of collecting them, since retaining all output
+//       costs more than the input it saves;
+//   (d) compare *live* heap after a forced GC, not raw heapUsed, which is
+//       mostly uncollected garbage.
+// Run with `node --expose-gc`; without it the numbers move with GC timing.
 console.log("\n3. Memory efficiency demo:");
 
-const largeData = generateLargeDataset(50000);
+const MEMO_SIZE = 200_000;
+const MEMO_CHUNK = 1000;
+const MEMO_PATTERNS = candlestick.allPatterns.slice(0, 5);
+const MEMO_NAMES = MEMO_PATTERNS.map((p) => p.name);
 
-console.log(`   Dataset: ${largeData.length} candles`);
+// Deterministic feed: both paths see the identical candle sequence, so the
+// match counts below should agree exactly. They are the proof that the two
+// measurements describe the same work.
+function makeFeed(seed) {
+  let state = seed;
+  let price = 100;
+  const rand = () => {
+    state = (state * 1103515245 + 12345) % 2147483648;
+    return state / 2147483648;
+  };
+  return function next(count) {
+    const out = [];
+    for (let i = 0; i < count; i++) {
+      price += (rand() - 0.5) * 5;
+      const close = price + (rand() - 0.5);
+      out.push({
+        open: price,
+        high: Math.max(price, close) + rand() * 2,
+        low: Math.min(price, close) - rand() * 2,
+        close,
+      });
+    }
+    return out;
+  };
+}
 
-// Regular patternChain (loads all in memory)
+// Live heap: what is still reachable after a collection, i.e. what the
+// approach actually requires resident.
+function liveHeapMb() {
+  if (global.gc) global.gc();
+  return process.memoryUsage().heapUsed / 1024 / 1024;
+}
+
+// Without --expose-gc a sample can land after a collection the previous one
+// missed, making a delta negative. Floor it at zero rather than printing a
+// nonsensical figure.
+function delta(now, base) {
+  return Math.max(0, now - base);
+}
+
+console.log(`   Dataset: ${MEMO_SIZE.toLocaleString()} candles`);
+if (!global.gc) {
+  console.log("   (run with `node --expose-gc` for stable measurements)");
+}
+
+// Batch: the whole dataset must exist as one array before detection starts,
+// and every match comes back at once. Both are alive when we sample.
 console.log("\n   Regular patternChain:");
-const memBefore = process.memoryUsage().heapUsed / 1024 / 1024;
-const regularResults = candlestick.patternChain(
-  largeData,
-  candlestick.allPatterns.slice(0, 5),
-);
-const memAfter = process.memoryUsage().heapUsed / 1024 / 1024;
-console.log(`     Memory delta: ${(memAfter - memBefore).toFixed(2)} MB`);
-console.log(`     Matches found: ${regularResults.length}`);
+const batchBase = liveHeapMb();
+let batchMatches;
+let batchLive;
+{
+  const feed = makeFeed(42);
+  const all = feed(MEMO_SIZE);
+  const found = candlestick.patternChain(all, MEMO_PATTERNS);
+  batchLive = delta(liveHeapMb(), batchBase); // all + found still referenced here
+  batchMatches = found.length;
+}
 
-// Streaming approach
+console.log(`     Live heap: ${batchLive.toFixed(2)} MB`);
+console.log(`     Matches found: ${batchMatches}`);
+
+// Streaming: candles are produced a chunk at a time and dropped once
+// processed, and matches are counted as they arrive. Sampled mid-run, where
+// the stream is carrying its buffer and everything else is garbage.
 console.log("\n   Streaming approach:");
-const memBefore2 = process.memoryUsage().heapUsed / 1024 / 1024;
-const streamResults = candlestick.streaming.processLargeDataset(largeData, {
-  patterns: candlestick.allPatterns.slice(0, 5).map((p) => p.name),
-  chunkSize: 1000,
+const streamBase = liveHeapMb();
+let streamMatches = 0;
+let streamLive = 0;
+const memoStream = candlestick.streaming.createStream({
+  patterns: MEMO_NAMES,
+  chunkSize: MEMO_CHUNK,
+  onMatch: () => {
+    streamMatches++;
+  },
 });
-const memAfter2 = process.memoryUsage().heapUsed / 1024 / 1024;
-console.log(`     Memory delta: ${(memAfter2 - memBefore2).toFixed(2)} MB`);
-console.log(`     Matches found: ${streamResults.length}`);
+const streamFeed = makeFeed(42);
+for (let i = 0; i < MEMO_SIZE; i += MEMO_CHUNK) {
+  memoStream.process(streamFeed(Math.min(MEMO_CHUNK, MEMO_SIZE - i)));
+  if (i === Math.floor(MEMO_SIZE / 2 / MEMO_CHUNK) * MEMO_CHUNK) {
+    streamLive = delta(liveHeapMb(), streamBase);
+  }
+}
+memoStream.end();
 
+console.log(`     Live heap: ${streamLive.toFixed(2)} MB`);
+console.log(`     Matches found: ${streamMatches}`);
+
+const savings = batchLive > 0 ? (1 - streamLive / batchLive) * 100 : 0;
 console.log(
-  "\n   Memory savings: ~",
-  ((1 - (memAfter2 - memBefore2) / (memAfter - memBefore)) * 100).toFixed(1),
-  "%",
+  `\n   Memory savings: ~${Math.min(99.9, Math.max(0, savings)).toFixed(1)}%` +
+    ` (${batchMatches === streamMatches ? "identical" : "DIFFERING"} match counts)` +
+    (global.gc ? "" : " — approximate, no --expose-gc"),
+);
+console.log(
+  "   Streaming memory is bounded by chunkSize, so the gap widens with dataset size.",
 );
 
 console.log("\n=== Demo Complete ===");


### PR DESCRIPTION
Fixes #135.

## What was wrong

The example reported 12.5%, 13.8% and 2.2% on three consecutive runs against a README claiming ~70%. **The claim was not the problem — the measurement was.** Three independent faults, each sufficient on its own to hide the effect:

1. **50,000 candles**, when the claim is explicitly scoped to datasets over 100K.
2. **Both paths used `processLargeDataset`**, which collects every match into an array. At tens of thousands of matches the result set dwarfs whatever the buffering saved.
3. **Both paths received a fully materialised input array.** That array stays resident however you then feed it, so there was nothing left for streaming to avoid holding — the benefit was structurally unmeasurable.

Plus it sampled raw `heapUsed`, which is mostly uncollected garbage. That is where the run-to-run swing came from.

## What it does now

Section 3 compares like with like:

- 200,000 candles, above the documented threshold
- a **seeded generator** both paths consume identically, so the comparison is not between two different random datasets
- the stream fed chunk by chunk, never materialising the dataset
- matches **counted** in `onMatch` rather than collected
- **live heap** sampled after a forced collection — what is actually still reachable

The printed match counts are the built-in fairness check. They now agree exactly:

```
   Regular patternChain:
     Live heap: 41.86 MB
     Matches found: 61866

   Streaming approach:
     Live heap: 0.18 MB
     Matches found: 61866

   Memory savings: ~99.6% (identical match counts)
```

Run without `--expose-gc` it stays sane — deltas are floored at zero, the percentage is capped, and the output says the figure is approximate.

## The README claim changed too

The measured result is far better than the advertised ~70%, so I replaced the figure instead of restating it. A single percentage was always the wrong shape: the saving **grows with dataset size**, because streaming memory is bounded by `chunkSize` while the batch path scales with input.

The README now states that bound, gives the measured numbers, and names the two conditions that forfeit the benefit — collecting matches, and feeding from an array you already built. Worth calling out explicitly: **`processLargeDataset` does both**, so it trades the memory benefit for a simpler call. That was previously undocumented, and it is precisely the trap the old example fell into.

## Verification

Lint 0 problems, Prettier clean, 443 tests passing, all 15 examples run. Repeated runs of the example give 99.6% consistently with `--expose-gc`, where the old one swung between 2.2% and 13.8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
