### PR TITLE
docs: refresh the README benchmark table and record where it came from

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,12 +541,14 @@ See [`examples/README.md`](./examples/README.md) for more details and instructio
 ## Performance
 
 <!-- BENCH:START -->
+
 | Dataset Size | Pattern Chain (ms) | Throughput (candles/sec) | Memory (MB) |
-|---|---|---|---|
-| 1,000 | 2.5 | 399K | <0.1 |
-| 10,000 | 23.5 | 426K | 3.5 |
-| 100,000 | 244.7 | 409K | 62.4 |
-| 1,000,000 | 2328.6 | 429K | 997.6 |
+| ------------ | ------------------ | ------------------------ | ----------- |
+| 1,000        | 2.7                | 370K                     | 0.6         |
+| 10,000       | 21.1               | 474K                     | 10.4        |
+| 100,000      | 227.1              | 440K                     | 47.7        |
+| 1,000,000    | 2436.9             | 410K                     | 891.8       |
+
 <!-- BENCH:END -->
 
 Measured on 2026-09-11 with `npm run bench:readme`, Node v24.21.0, Intel Core

--- a/README.md
+++ b/README.md
@@ -541,15 +541,20 @@ See [`examples/README.md`](./examples/README.md) for more details and instructio
 ## Performance
 
 <!-- BENCH:START -->
-
 | Dataset Size | Pattern Chain (ms) | Throughput (candles/sec) | Memory (MB) |
-| ------------ | ------------------ | ------------------------ | ----------- |
-| 1,000        | 7.0                | 142K                     | 1.7         |
-| 10,000       | 29.9               | 334K                     | 16.6        |
-| 100,000      | 294.7              | 339K                     | 114.8       |
-| 1,000,000    | 2288.8             | 437K                     | 667.5       |
-
+|---|---|---|---|
+| 1,000 | 2.5 | 399K | <0.1 |
+| 10,000 | 23.5 | 426K | 3.5 |
+| 100,000 | 244.7 | 409K | 62.4 |
+| 1,000,000 | 2328.6 | 429K | 997.6 |
 <!-- BENCH:END -->
+
+Measured on 2026-09-11 with `npm run bench:readme`, Node v24.21.0, Intel Core
+i7-9750H @ 2.60GHz, 16 GB RAM, macOS 26.6. Figures are single-run and
+machine-specific — treat them as an order of magnitude, not a guarantee.
+Regenerate with `npm run bench:readme`, and update this line when you do. Memory
+on the smallest dataset is below the resolution of `process.memoryUsage()`,
+hence `<0.1`.
 
 When calling multiple pattern functions on the same dataset, use `precomputeCandleProps` to avoid redundant work:
 

--- a/scripts/update-bench.js
+++ b/scripts/update-bench.js
@@ -53,6 +53,23 @@ function formatMemory(mb) {
   return mb < 0.1 ? "<0.1" : mb.toFixed(1);
 }
 
+function writeFormatted(filePath, contents) {
+  const prettier = require("prettier");
+  const config = prettier.resolveConfig.sync
+    ? prettier.resolveConfig.sync(filePath)
+    : null;
+  const formatted = prettier.format(contents, {
+    ...(config || {}),
+    filepath: filePath,
+  });
+  // prettier v3 returns a promise; v2 returns a string.
+  if (typeof formatted.then === "function") {
+    return formatted.then((out) => fs.writeFileSync(filePath, out));
+  }
+  fs.writeFileSync(filePath, formatted);
+  return undefined;
+}
+
 function updateReadme(results) {
   const readme = fs.readFileSync(readmePath, "utf8");
 
@@ -84,7 +101,12 @@ function updateReadme(results) {
     readme.slice(0, startIdx) +
     newContent +
     readme.slice(endIdx + endMarker.length);
-  fs.writeFileSync(readmePath, updated);
+
+  // The rows above are emitted unpadded, which is valid Markdown but not what
+  // prettier produces, so writing them raw leaves `npm run format:check`
+  // failing until someone notices. Format the result the same way the repo
+  // does instead of hand-rolling prettier's column padding.
+  writeFormatted(readmePath, updated);
 
   console.log("\nREADME.md performance table updated:");
   console.log(table);

--- a/scripts/update-bench.js
+++ b/scripts/update-bench.js
@@ -45,6 +45,14 @@ function formatSize(n) {
   return n.toLocaleString("en-US");
 }
 
+// Heap deltas on the smallest datasets are below the resolution of
+// process.memoryUsage(): a collection between the two samples can even make
+// them negative. Report that as a bound instead of printing a number the
+// measurement cannot support.
+function formatMemory(mb) {
+  return mb < 0.1 ? "<0.1" : mb.toFixed(1);
+}
+
 function updateReadme(results) {
   const readme = fs.readFileSync(readmePath, "utf8");
 
@@ -66,7 +74,7 @@ function updateReadme(results) {
     .filter((r) => r.size >= 1000)
     .map(
       (r) =>
-        `| ${formatSize(r.size)} | ${r.chainMs.toFixed(1)} | ${formatThroughput(r.throughput)} | ${r.memoryMb.toFixed(1)} |`,
+        `| ${formatSize(r.size)} | ${r.chainMs.toFixed(1)} | ${formatThroughput(r.throughput)} | ${formatMemory(r.memoryMb)} |`,
     );
 
   const table = [header, separator, ...rows].join("\n");


### PR DESCRIPTION
Fixes #136.

Takes option 1 from the issue: regenerate, and state where the numbers came from.

## Regenerated

| dataset | was | now |
|---|---|---|
| 1,000 | 7.0 ms / 142K per sec | 2.7 ms / 370K per sec |
| 10,000 | 29.9 ms / 334K per sec | 21.1 ms / 474K per sec |
| 100,000 | 294.7 ms / 339K per sec | 227.1 ms / 440K per sec |
| 1,000,000 | 2288.8 ms / 437K per sec | 2436.9 ms / 410K per sec |

## Provenance, so this does not silently rot again

Regenerating alone would leave the same trap. A line below the table — **outside the `BENCH` markers**, so `bench:readme` cannot overwrite it — records the date, Node version and machine, and says plainly that the figures are single-run and machine-specific.

That wording is doing real work: across three runs on this machine the 1M row ranged **2296–2437 ms**, roughly 6%. These are an order of magnitude, not a guarantee.

## Two defects the regeneration exposed

**1. Negative memory on the smallest dataset.** The first fresh run produced `-0.1 MB` at 1,000 candles. Heap deltas that small are below the resolution of `process.memoryUsage()`, and a collection between the two samples can push them negative — the same measurement problem as #135, elsewhere. `update-bench.js` now renders anything under 0.1 MB as `<0.1`, a bound the measurement supports.

**2. `bench:readme` left the repo unformatted.** The generator emits table rows unpadded (`|---|---|---|---|`), valid Markdown but not what prettier produces, so every run left `npm run format:check` failing until someone ran `format`. The second commit here runs the README through prettier with the repo's resolved config after writing, instead of hand-rolling the column padding.

I hit this the hard way: the first commit on this branch shipped that unformatted state, because a benchmark run finished and rewrote `README.md` *after* I had verified the check. The table has since been regenerated on an otherwise idle machine and the tree verified clean.

**Neither change touches the tracked baseline.** `benchmark.js` and the JSON consumed by `github-action-benchmark` are untouched — only how `update-bench` renders the README — so this cannot trigger a false regression alert.

## Verification

Lint 0 problems, `format:check` clean, 443 tests passing, and `npm run bench:readme` re-run after the change leaves the tree formatted and the provenance line intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHrbijd7A9mMK2qydRKRJ
