### PR TITLE
fix(cli): size table columns to their content

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -196,31 +196,59 @@ function outputTable(results) {
     return;
   }
 
-  console.log(
-    "\n┌─────────┬─────────────────────┬────────────┬────────────┬────────────┐",
+  const columns = [
+    { header: "Index", min: 7, value: (r) => String(r.index) },
+    { header: "Pattern", min: 19, value: (r) => String(r.pattern) },
+    {
+      header: "Type",
+      min: 10,
+      value: (r) => String((r.metadata || {}).type || "N/A"),
+    },
+    {
+      header: "Confidence",
+      min: 10,
+      value: (r) => {
+        const { confidence } = r.metadata || {};
+        return confidence ? confidence.toFixed(2) : "N/A";
+      },
+    },
+    {
+      header: "Strength",
+      min: 10,
+      value: (r) => String((r.metadata || {}).strength || "N/A"),
+    },
+  ];
+
+  // Widen each column to its longest cell so long pattern names cannot
+  // overflow and break the box borders.
+  const widths = columns.map((col) =>
+    results.reduce(
+      (width, r) => Math.max(width, col.value(r).length),
+      Math.max(col.min, col.header.length),
+    ),
   );
-  console.log(
-    "│  Index  │       Pattern       │    Type    │ Confidence │  Strength  │",
-  );
-  console.log(
-    "├─────────┼─────────────────────┼────────────┼────────────┼────────────┤",
-  );
+
+  const rule = (left, mid, right) =>
+    left + widths.map((w) => "─".repeat(w + 2)).join(mid) + right;
+
+  const center = (text, width) => {
+    const pad = width - text.length;
+    return (
+      " ".repeat(Math.floor(pad / 2)) + text + " ".repeat(Math.ceil(pad / 2))
+    );
+  };
+
+  const row = (cells) => `│ ${cells.join(" │ ")} │`;
+
+  console.log("\n" + rule("┌", "┬", "┐"));
+  console.log(row(columns.map((col, i) => center(col.header, widths[i]))));
+  console.log(rule("├", "┼", "┤"));
 
   results.forEach((r) => {
-    const meta = r.metadata || {};
-    const index = String(r.index).padEnd(7);
-    const pattern = String(r.pattern).padEnd(19);
-    const type = String(meta.type || "N/A").padEnd(10);
-    const conf = String(
-      meta.confidence ? meta.confidence.toFixed(2) : "N/A",
-    ).padEnd(10);
-    const strength = String(meta.strength || "N/A").padEnd(10);
-    console.log(`│ ${index} │ ${pattern} │ ${type} │ ${conf} │ ${strength} │`);
+    console.log(row(columns.map((col, i) => col.value(r).padEnd(widths[i]))));
   });
 
-  console.log(
-    "└─────────┴─────────────────────┴────────────┴────────────┴────────────┘",
-  );
+  console.log(rule("└", "┴", "┘"));
   console.log(`\nTotal patterns detected: ${results.length}\n`);
 }
 

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -55,6 +55,24 @@ describe("CLI Output Functions", () => {
     assert.ok(logs.length > 0);
   });
 
+  it("keeps table borders aligned when a pattern name is wider than the column", () => {
+    const cli = require("../cli/index.js");
+
+    cli.outputTable([
+      { index: 0, pattern: "bearishInvertedHammer" },
+      { index: 1, pattern: "doji" },
+    ]);
+
+    const box = logs.filter((line) => /^[┌├└│]/.test(line.trim()));
+    assert.equal(box.length, 6, "expected 3 rules, a header and 2 data rows");
+
+    const widths = new Set(box.map((line) => [...line.trim()].length));
+    assert.equal(widths.size, 1, `border widths differ: ${[...widths]}`);
+
+    const longRow = box.find((line) => line.includes("bearishInvertedHammer"));
+    assert.ok(longRow.trim().endsWith("│"), "long row must close its border");
+  });
+
   it("outputs results in CSV format", () => {
     const cli = require("../cli/index.js");
 


### PR DESCRIPTION
## Problem

`candlestick --output table` hardcoded both the column widths and the border strings. Any cell wider than its column pushed the row past the box, breaking the alignment of every rule. The Pattern column is 19 chars, but `bearishInvertedHammer` is 21:

```
┌─────────┬─────────────────────┬────────────┬────────────┬────────────┐
│  Index  │       Pattern       │    Type    │ Confidence │  Strength  │
├─────────┼─────────────────────┼────────────┼────────────┼────────────┤
│ 0       │ bearishEngulfing    │ N/A        │ N/A        │ N/A        │
│ 1       │ invertedHammer      │ N/A        │ N/A        │ N/A        │
│ 1       │ bearishInvertedHammer │ N/A        │ N/A        │ N/A        │
└─────────┴─────────────────────┴────────────┴────────────┴────────────┘
```

`bearishHangingMan`, `bullishSpinningTop` and friends sit just under the limit, so this only shows up on the longest names.

## Fix

Declare the columns once with a header, a minimum width and a value accessor, then compute each width from the longest cell and build the rules from those widths. The previous widths become the minimums, so **output for short pattern names is byte-identical** to before — only rows that used to overflow change.

```
┌─────────┬───────────────────────┬────────────┬────────────┬────────────┐
│  Index  │        Pattern        │    Type    │ Confidence │  Strength  │
├─────────┼───────────────────────┼────────────┼────────────┼────────────┤
│ 0       │ bearishEngulfing      │ N/A        │ N/A        │ N/A        │
│ 1       │ invertedHammer        │ N/A        │ N/A        │ N/A        │
│ 1       │ bearishInvertedHammer │ N/A        │ N/A        │ N/A        │
└─────────┴───────────────────────┴────────────┴────────────┴────────────┘
```

## Verification

- New test in `test/cli-output.test.js` asserts every border line has the same width and that a long row closes its border.
- `npm test` — 444/444 pass (443 before, +1 new).
- `npm run lint` and `npm run format:check` clean.
- Checked by hand against the real binary with and without `--metadata`, and confirmed the short-name table matches the old fixed-width output exactly.

## Out of scope

The `N/A` in Type/Confidence/Strength when `--metadata` is not passed is tracked separately — it is a decision about the output contract, not a rendering bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxi5vDLKgd4Gu3Q3y9bxDN