### PR TITLE
feat(cli): always include metadata in table and csv output

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Detect patterns from command line:
 npm install -g candlestick
 
 # Detect patterns in JSON file
-candlestick -i data.json --output table --metadata
+candlestick -i data.json --output table
 
 # Filter by confidence
 candlestick -i data.csv --confidence 0.85 --output csv

--- a/cli/index.js
+++ b/cli/index.js
@@ -6,6 +6,9 @@ const path = require("path");
 const candlestick = require("../index.js");
 
 const { version } = require("../package.json");
+// Output formats with fixed metadata columns, which therefore always enrich.
+const TABULAR_FORMATS = new Set(["table", "csv"]);
+
 const BANNER_TITLE = `Candlestick Pattern Detection CLI v${version}`;
 const BANNER_WIDTH = 62;
 const BANNER_PAD = Math.max(0, BANNER_WIDTH - BANNER_TITLE.length);
@@ -27,7 +30,8 @@ Options:
   -t, --type <type>        Filter by type: reversal, continuation, neutral
   -d, --direction <dir>    Filter by direction: bullish, bearish, neutral
   --validate               Validate OHLC data before processing
-  --metadata               Include pattern metadata in output
+  --metadata               Include pattern metadata in JSON output
+                           (table and csv always include it)
   --help, -h               Show this help message
 
 Examples:
@@ -163,8 +167,18 @@ function processData(data, args) {
   // Detect patterns
   let results = candlestick.patternChain(data, patterns);
 
-  // Enrich with metadata
-  if (args.metadata || args.confidence > 0 || args.type || args.direction) {
+  // Enrich with metadata. The table and CSV formats always print the type,
+  // direction, confidence and strength columns, so they always need it —
+  // otherwise those columns render empty and read as "could not classify".
+  // Enrichment is a lookup against PATTERN_METADATA (~2.5% of detection time).
+  const needsMetadata =
+    args.metadata ||
+    args.confidence > 0 ||
+    args.type ||
+    args.direction ||
+    TABULAR_FORMATS.has(args.output);
+
+  if (needsMetadata) {
     results = candlestick.metadata.enrichWithMetadata(results);
   }
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -48,8 +48,13 @@ cat data.json | candlestick --output table
 | `--type <type>`      | `-t`  | Filter by type: reversal, continuation, neutral | none    |
 | `--direction <dir>`  | `-d`  | Filter by direction: bullish, bearish, neutral  | none    |
 | `--validate`         |       | Validate OHLC data before processing            | false   |
-| `--metadata`         |       | Include pattern metadata in output              | false   |
+| `--metadata`         |       | Include pattern metadata in JSON output         | false   |
 | `--help`             | `-h`  | Show help message                               |         |
+
+`--metadata` only affects `--output json`, where it adds a nested `metadata`
+object to each result. The `table` and `csv` formats have fixed type,
+direction, confidence and strength columns, so they always include metadata
+whether or not the flag is passed.
 
 ## Input Formats
 
@@ -100,7 +105,7 @@ candlestick -i data.json --output json --metadata
 ### Table Output
 
 ```bash
-candlestick -i data.json --output table --metadata
+candlestick -i data.json --output table
 ```
 
 ```
@@ -115,7 +120,7 @@ candlestick -i data.json --output table --metadata
 ### CSV Output
 
 ```bash
-candlestick -i data.json --output csv --metadata
+candlestick -i data.json --output csv
 ```
 
 ```csv

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -73,6 +73,74 @@ describe("CLI Output Functions", () => {
     assert.ok(longRow.trim().endsWith("│"), "long row must close its border");
   });
 
+  it("populates the metadata columns for table and csv without --metadata", () => {
+    const cli = require("../cli/index.js");
+
+    const testData = [
+      { open: 50, high: 51, low: 40, close: 41 },
+      { open: 38, high: 48, low: 37, close: 47 },
+    ];
+    const baseArgs = {
+      patterns: null,
+      confidence: 0,
+      type: null,
+      direction: null,
+      validate: false,
+      metadata: false,
+    };
+
+    for (const output of ["table", "csv"]) {
+      const results = cli.processData(testData, { ...baseArgs, output });
+      assert.ok(results.length > 0, `no patterns detected for ${output}`);
+      for (const r of results) {
+        assert.ok(r.metadata, `${output}: missing metadata on ${r.pattern}`);
+        assert.ok(r.metadata.type, `${output}: missing type`);
+        assert.equal(typeof r.metadata.confidence, "number");
+      }
+    }
+
+    // The CSV header must keep its six fixed columns, in order.
+    logs = [];
+    cli.outputCSV(cli.processData(testData, { ...baseArgs, output: "csv" }));
+    assert.equal(
+      logs[0],
+      "index,pattern,type,direction,confidence,strength",
+      "CSV column contract changed",
+    );
+    assert.ok(
+      logs.slice(1).every((line) => line.split(",").length === 6),
+      "every CSV row must have six fields",
+    );
+  });
+
+  it("leaves json output untouched unless --metadata is passed", () => {
+    const cli = require("../cli/index.js");
+
+    const testData = [
+      { open: 50, high: 51, low: 40, close: 41 },
+      { open: 38, high: 48, low: 37, close: 47 },
+    ];
+    const args = {
+      patterns: null,
+      confidence: 0,
+      type: null,
+      direction: null,
+      validate: false,
+      metadata: false,
+      output: "json",
+    };
+
+    const plain = cli.processData(testData, args);
+    assert.ok(plain.length > 0);
+    assert.ok(
+      plain.every((r) => r.metadata === undefined),
+      "json must not gain metadata implicitly",
+    );
+
+    const enriched = cli.processData(testData, { ...args, metadata: true });
+    assert.ok(enriched.every((r) => r.metadata));
+  });
+
   it("outputs results in CSV format", () => {
     const cli = require("../cli/index.js");
 


### PR DESCRIPTION
Closes #141.

## Problem

`table` and `csv` always print the type, direction, confidence and strength columns, but only populated them when `--metadata` was passed. Without it:

```console
$ candlestick -i data.csv -o table
│ 0       │ bearishEngulfing      │ N/A        │ N/A        │ N/A        │

$ candlestick -i data.csv -o csv
index,pattern,type,direction,confidence,strength
0,bearishEngulfing,,,,
```

That reads as "the pattern could not be classified", when the data was simply never requested.

Worth noting the scope is narrow: `processData` already forced enrichment for `--confidence`, `--type` and `--direction`, so filtered runs were always correct. The empty columns appeared only with no `--metadata` **and** no filter.

## Change

Enrich unconditionally for both tabular formats:

```js
const needsMetadata =
  args.metadata || args.confidence > 0 || args.type || args.direction ||
  TABULAR_FORMATS.has(args.output);
```

```console
$ candlestick -i data.csv -o table
│ 0       │ bearishEngulfing      │ reversal   │ 0.85       │ strong     │

$ candlestick -i data.csv -o csv
index,pattern,type,direction,confidence,strength
0,bearishEngulfing,reversal,bearish,0.85,strong
```

## Compatibility

The CSV header keeps its six columns in the same order — only the values change, from empty to populated. A consumer that broke on that would be depending on the *absence* of data. The alternative considered in #141, dropping the columns when unpopulated, would have made the column count data-dependent and broken any parser assuming six fixed fields; it was rejected for that reason.

`json` output is unchanged and still requires `--metadata`. The flag is therefore json-only now, and `--help`, `README.md` and `docs/CLI_GUIDE.md` say so.

## Cost

`enrichWithMetadata` is a lookup against `PATTERN_METADATA`, not a recomputation. On 100,000 candles / 67,354 matches: detection 358 ms, enrichment 9 ms — **+2.5%**. Nothing to save by skipping it.

## Verification

- Two new tests: metadata is present for both tabular formats without the flag, the CSV header and six-field row shape are pinned, and `json` is asserted *not* to gain metadata implicitly.
- `npm test` — 446/446 pass (444 before, +2).
- `npm run lint` and `npm run format:check` clean.
- Checked by hand against the real binary for all three formats, with and without the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxi5vDLKgd4Gu3Q3y9bxDN