### PR TITLE
test: cover the first-candle shadow guards in the three-candle patterns

### DIFF
--- a/test/threeBlackCrows.test.js
+++ b/test/threeBlackCrows.test.js
@@ -14,6 +14,18 @@ describe("threeBlackCrows", () => {
     assert.equal(isThreeBlackCrows(first, second, third), true);
   });
 
+  it("isThreeBlackCrows: rejects when the first candle's lower shadow exceeds 30% of its body", () => {
+    // Body 10, tail 4 (90 - 86) — over the 30% limit, so the guard rejects it.
+    const first = { open: 100, high: 100, low: 86, close: 90 };
+    const second = { open: 95, high: 95, low: 85, close: 85 };
+    const third = { open: 90, high: 90, low: 80, close: 80 };
+    assert.equal(isThreeBlackCrows(first, second, third), false);
+
+    // Same triple with no tail on the first candle: the guard is what rejected it.
+    const noTail = { ...first, low: 90 };
+    assert.equal(isThreeBlackCrows(noTail, second, third), true);
+  });
+
   it("isThreeBlackCrows: rejects when any candle is bullish", () => {
     const first = { open: 30, high: 31, low: 20, close: 21 };
     const second = { open: 17, high: 27, low: 16, close: 26 }; // Bullish

--- a/test/threeWhiteSoldiers.test.js
+++ b/test/threeWhiteSoldiers.test.js
@@ -14,6 +14,18 @@ describe("threeWhiteSoldiers", () => {
     assert.equal(isThreeWhiteSoldiers(first, second, third), true);
   });
 
+  it("isThreeWhiteSoldiers: rejects when the first candle's upper shadow exceeds 30% of its body", () => {
+    // Body 10, wick 4 (104 - 100) — over the 30% limit, so the guard rejects it.
+    const first = { open: 90, high: 104, low: 90, close: 100 };
+    const second = { open: 95, high: 105, low: 95, close: 105 };
+    const third = { open: 100, high: 110, low: 100, close: 110 };
+    assert.equal(isThreeWhiteSoldiers(first, second, third), false);
+
+    // Same triple with no wick on the first candle: the guard is what rejected it.
+    const noWick = { ...first, high: 100 };
+    assert.equal(isThreeWhiteSoldiers(noWick, second, third), true);
+  });
+
   it("isThreeWhiteSoldiers: rejects when any candle is bearish", () => {
     const first = { open: 10, high: 20, low: 9, close: 19 };
     const second = { open: 24, high: 25, low: 14, close: 15 }; // Bearish


### PR DESCRIPTION
## Context

`c8@12` (#143) flagged two uncovered branches that `c8@11` had missed:

```
threeBlackCrows.js    | 100 | 97.5  | 100 | 100 | 58
threeWhiteSoldiers.js | 100 | 97.22 | 100 | 100 | 58
```

Both are the guard rejecting a first candle whose shadow is more than 30% of its body:

```js
// threeBlackCrows.js:58      if (c1.tailLen > c1.bodyLen * 0.3) return false;
// threeWhiteSoldiers.js:58   if (c1.wickLen > c1.bodyLen * 0.3) return false;
```

## Why they were uncovered

Both files already had tests named for large shadows — including ones explicitly for the second and third candles. But every existing case that gave the *first* candle a large shadow also tripped an earlier guard (body-to-range ratio, or the opens-within-previous-body checks), so the function returned before reaching line 58 and that branch never took its true path.

## Change

Two tests, one per file, constructing a triple that satisfies every preceding condition and fails *only* on the shadow:

```js
// Body 10, tail 4 (90 - 86) — over the 30% limit, so the guard rejects it.
const first = { open: 100, high: 100, low: 86, close: 90 };
const second = { open: 95, high: 95, low: 85, close: 85 };
const third = { open: 90, high: 90, low: 80, close: 80 };
assert.equal(isThreeBlackCrows(first, second, third), false);

// Same triple with no tail on the first candle: the guard is what rejected it.
const noTail = { ...first, low: 90 };
assert.equal(isThreeBlackCrows(noTail, second, third), true);
```

The second assertion is the point: without it the test would pass even if some unrelated guard were doing the rejecting. Proving the same triple is accepted once the shadow is removed pins the behaviour to this guard specifically.

Pure unit tests against the exported predicates, no fixtures.

## Result

| | Before | After |
|---|---|---|
| `src/` branch | 99.57% | **99.86%** |
| Overall branch | 98.65% | **98.90%** |
| `threeBlackCrows.js` | 97.5% branch | **100%** |
| `threeWhiteSoldiers.js` | 97.22% branch | **100%** |

`npm test` 448/448 (446 before, +2). `eslint` exit 0, `prettier --check` clean.

## What is still uncovered

For the record, the remaining gaps are structural rather than missing tests:

- `cli/index.js:105-106` — the stdin branch of `readInput` (`fs.readFileSync(0)`), exercised by the real binary through a pipe but not reachable in-process.
- `cli/index.js:326-327` — the `if (require.main === module)` entry guard, never true under `node --test` by construction.
- `src/utils.js:237-238` — a `return false` in a validation catch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxi5vDLKgd4Gu3Q3y9bxDN