### PR TITLE
ci: test on node 26 as well

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,10 @@ Thank you for your interest in contributing! Your help is welcome and appreciate
 ## Supported Node.js Versions
 
 The package requires Node.js >= 20 (`package.json#engines`). CI runs the full
-suite on **20.x, 22.x and 24.x** across Linux, Windows and macOS, so a change
-must pass on all three before it can merge. Develop on a version inside that
-range; anything that only works on a newer runtime will fail the 20.x jobs.
+suite on **20.x, 22.x, 24.x and 26.x** across Linux, Windows and macOS, so a
+change must pass on all four before it can merge. Develop on a version inside
+that range; anything that only works on a newer runtime will fail the 20.x
+jobs.
 
 `.nvmrc` pins **20.19**, the floor, so `nvm use` puts you on the oldest
 supported runtime — the one most likely to catch an accidental dependency on a


### PR DESCRIPTION
## Why

Node 26 becomes **Active LTS on 2026-10-28**, roughly seven weeks out, so it will be the recommended runtime shortly. From the official release schedule:

| Version | Status | LTS from | EOL |
|---|---|---|---|
| v20.20.2 | **EOL** | 2023-10-24 | **2026-04-30** |
| v22.23.2 | Maintenance | 2024-10-29 | 2027-04-30 |
| v24.21.0 | Active LTS | 2025-10-28 | 2028-04-30 |
| v26.8.2 | Current | **2026-10-28** | 2029-04-30 |

There is already a worked example of the cost of not testing it: `c8@11` could not start on Node 26 at all (`ReferenceError: require is not defined in ES module scope`), so `npm run coverage` was completely broken there. That went unnoticed for as long as it existed, because the matrix stopped at 24 — it only surfaced when the script was run locally on 26, and was fixed in #143.

## Change

```diff
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
```

`CONTRIBUTING.md` names the matrix explicitly ("CI runs the full suite on **20.x, 22.x and 24.x**"), so it is updated in the same commit to stay accurate.

## Cost

9 jobs → 12, on a suite that runs in ~1.5s. Each new job does `npm ci`, lint, test and coverage like the others.

## Verification

The full gate already runs on Node 26 locally, which is where this change will be exercised: `npm test` 448/448, coverage 99.82% lines / 100% functions, `eslint` exit 0, `prettier --check` clean. The workflow YAML parses and the matrix expands to the 12 expected jobs.

The three new jobs in this PR's own checks are the real verification.

## Not in scope: Node 20

The table above shows Node 20 has been **EOL since 2026-04-30**, so a quarter of the matrix currently tests an unsupported runtime and `package.json#engines` still says `>=20`.

Dropping it is deliberately left out of this PR: raising `engines` is a breaking change for consumers and belongs to a major release, whereas adding 26.x breaks nothing. Worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mxi5vDLKgd4Gu3Q3y9bxDN