### PR TITLE
fix(cli): honour "-" as stdin when picking the parser

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -99,18 +99,17 @@ function parseArgs() {
 }
 
 function readInput(inputPath) {
-  let data;
+  // One source of truth for "this is stdin": an omitted path and an explicit
+  // "-" must agree, both when reading and when picking the parser.
+  const fromStdin = !inputPath || inputPath === "-";
 
-  if (!inputPath || inputPath === "-") {
-    // Read from stdin
-    data = fs.readFileSync(0, "utf-8");
-  } else {
-    data = fs.readFileSync(inputPath, "utf-8");
-  }
+  const data = fromStdin
+    ? fs.readFileSync(0, "utf-8")
+    : fs.readFileSync(inputPath, "utf-8");
 
-  const ext = inputPath ? path.extname(inputPath).toLowerCase() : ".json";
+  const ext = fromStdin ? ".json" : path.extname(inputPath).toLowerCase();
 
-  if (ext === ".json" || !inputPath) {
+  if (ext === ".json") {
     return JSON.parse(data);
   } else if (ext === ".csv") {
     return parseCSV(data);

--- a/cli/index.js
+++ b/cli/index.js
@@ -24,6 +24,7 @@ Usage: candlestick [options]
 
 Options:
   -i, --input <file>       Input CSV or JSON file with OHLC data
+                           ("-", or omitted, reads JSON from stdin)
   -o, --output <format>    Output format: json, table, csv (default: json)
   -p, --patterns <list>    Comma-separated pattern names (default: all)
   -c, --confidence <min>   Minimum confidence threshold 0-1 (default: 0)
@@ -39,6 +40,7 @@ Examples:
   candlestick -i data.csv --patterns hammer,doji --output table
   candlestick -i data.json --confidence 0.8 --type reversal
   cat data.json | candlestick --output csv
+  cat data.json | candlestick -i - --output csv
 
 Input Format:
   JSON: Array of {open, high, low, close} objects

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -33,15 +33,19 @@ candlestick -i data.csv --output table
 
 ### Use with Pipes (stdin)
 
+Omitting `--input` reads from stdin, and `-` is accepted as an explicit
+spelling of the same thing. Piped data is always parsed as JSON.
+
 ```bash
 cat data.json | candlestick --output table
+cat data.json | candlestick --input - --output table
 ```
 
 ## Options
 
 | Option               | Short | Description                                     | Default |
 | -------------------- | ----- | ----------------------------------------------- | ------- |
-| `--input <file>`     | `-i`  | Input CSV or JSON file                          | stdin   |
+| `--input <file>`     | `-i`  | Input CSV or JSON file, or `-` for stdin (JSON) | stdin   |
 | `--output <format>`  | `-o`  | Output format: json, table, csv                 | json    |
 | `--patterns <list>`  | `-p`  | Comma-separated pattern names                   | all     |
 | `--confidence <min>` | `-c`  | Minimum confidence threshold (0-1)              | 0       |

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -141,6 +141,33 @@ describe("CLI Output Functions", () => {
     assert.ok(enriched.every((r) => r.metadata));
   });
 
+  it('reads stdin both when the path is omitted and when it is "-"', () => {
+    const cli = require("../cli/index.js");
+    const fs = require("node:fs");
+
+    const payload = '[{"open":1,"high":2,"low":0,"close":1.5}]';
+    const real = fs.readFileSync;
+    const seen = [];
+    fs.readFileSync = (fd) => {
+      seen.push(fd);
+      return payload;
+    };
+
+    try {
+      // Both spellings must read fd 0 and parse it as JSON. "-" used to read
+      // stdin correctly and then die on "Unsupported file format: ".
+      for (const path of [null, "-"]) {
+        const data = cli.readInput(path);
+        assert.equal(data.length, 1);
+        assert.equal(data[0].open, 1);
+      }
+    } finally {
+      fs.readFileSync = real;
+    }
+
+    assert.deepEqual(seen, [0, 0], "both calls must read file descriptor 0");
+  });
+
   it("outputs results in CSV format", () => {
     const cli = require("../cli/index.js");
 

--- a/test/cli-output.test.js
+++ b/test/cli-output.test.js
@@ -222,8 +222,10 @@ describe("CLI Output Functions", () => {
     assert.ok(logs.length > 0);
   });
 
-  it("handles stdin input", () => {
-    // Test that processData works with data from stdin
+  it("processData accepts an already-parsed candle array", () => {
+    // Named "handles stdin input" until it was pointed out that nothing here
+    // touches stdin or readInput; the real stdin coverage is the fd 0 test
+    // above. Keep this one for what it does test: processData on a plain array.
     const testData = [
       { open: 100, high: 110, low: 95, close: 105 },
       { open: 105, high: 115, low: 100, close: 110 },

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -148,11 +148,30 @@ describe("validateOHLCArray", () => {
     assert.equal(validateOHLCArray(candles, false), false);
   });
 
+  it("returns false instead of throwing when a candle's own getter throws", () => {
+    // Nothing in validateOHLC throws with throwError=false, so the loop's
+    // catch is only reachable when reading the candle itself throws.
+    const boom = {
+      get open() {
+        throw new Error("exploding getter");
+      },
+      high: 1,
+      low: 1,
+      close: 1,
+    };
+
+    assert.equal(validateOHLCArray([boom], false), false);
+    assert.throws(
+      () => validateOHLCArray([boom], true),
+      /Invalid candle at index 0: exploding getter/,
+    );
+  });
+
   it("catches validation error in loop when throwError is false", () => {
     // This test specifically targets the catch block in validateOHLCArray
     const candles = [
       { open: 10, high: 15, low: 8, close: 12 },
-      null, // This will cause validateOHLC to throw
+      null, // validateOHLC returns false for this; it does not throw
     ];
     assert.equal(validateOHLCArray(candles, false), false);
   });


### PR DESCRIPTION
## The bug

`candlestick -i -` read stdin correctly and then died on it:

```console
$ echo '[{"open":10,...}]' | ./bin/candlestick -i - -o csv
Error: Unsupported file format: . Use .json or .csv     (exit 1)

$ echo '[{"open":10,...}]' | ./bin/candlestick -o csv    # no -i, works fine
index,pattern,type,direction,confidence,strength
0,bearishEngulfing,reversal,bearish,0.85,strong
```

`readInput` decided "this is stdin" twice, and the two spellings disagreed:

```js
if (!inputPath || inputPath === "-") {   // read branch: accepts both
  data = fs.readFileSync(0, "utf-8");
...
const ext = inputPath ? path.extname(inputPath).toLowerCase() : ".json";
if (ext === ".json" || !inputPath) {     // parser branch: only the omitted path
```

`path.extname("-")` is `""`, so `-` fell past both the `.json` and `.csv` arms into the unsupported-format throw.

## Fix

Derive it once, use it for both decisions:

```js
const fromStdin = !inputPath || inputPath === "-";

const data = fromStdin
  ? fs.readFileSync(0, "utf-8")
  : fs.readFileSync(inputPath, "utf-8");

const ext = fromStdin ? ".json" : path.extname(inputPath).toLowerCase();
```

The duplicated condition was the defect, so the fix removes it rather than patching the second copy. The dropped `|| !inputPath` arm was unreachable as a deciding condition: when `inputPath` is falsy, `ext` was already `".json"`.

Reading from a path, `.json`, `.csv` and the unsupported-extension error are all unchanged, verified case by case:

| Input | Result | vs. before |
| --- | --- | --- |
| `-i -` | works | **fixed** |
| no `-i` | works | unchanged |
| `-i data.json` / `-i data.csv` | works | unchanged |
| `-i data.txt` | `Unsupported file format: .txt` | unchanged |
| extensionless path | `Unsupported file format: .` | unchanged |
| `-i` with no value | reads stdin | unchanged |
| missing file | `ENOENT` | unchanged |

## Commits

Four focused commits, each green on its own so the history stays bisectable:

1. **`fix(cli)`** — the one-predicate fix plus its stdin regression test.
2. **`docs(cli)`** — `-` was only ever advertised inside `readInput`; neither `--help` nor the CLI guide mentioned it, so the one explicit way to ask for stdin was undiscoverable. Both now name it, and both state that piped input is parsed as JSON.
3. **`test(cli)`** — renames the test that hid this bug (see below).
4. **`test(utils)`** — the `validateOHLCArray` coverage work, split out of the fix, which had no reason to carry it.

## Why this shipped broken

`test/cli-output.test.js` had a test named **`"handles stdin input"`** that never touched stdin — it passed a literal array to `processData`, never reaching `readInput` or fd 0. The suite advertised coverage it did not have. It is renamed to `"processData accepts an already-parsed candle array"`, with a comment pointing at the real fd 0 test, so the gap cannot be re-hidden.

The same pattern appeared in `validation.test.js`: a test aimed at `validateOHLCArray`'s `catch` with a `null` candle and a comment claiming that "will cause `validateOHLC` to throw". It returns `false` once `throwError` is false, so the branch was never entered. Comment corrected; a candle whose getter throws does reach it.

## Tests

Both new tests are reachable without touching production code:

1. **The stdin branch of `readInput`**, by stubbing `fs.readFileSync` and restoring it in a `finally`. Asserts both spellings read fd 0 and parse as JSON. Against the pre-fix code it fails with exactly `Unsupported file format: .`, so it is a real regression test, not a coverage filler.
2. **`validateOHLCArray`'s loop `catch` with `throwError=false`**, via an exploding getter — the last dark branch in `src/utils.js`.

Verified: 450/450 pass; 449 on each of the first three commits. `eslint` and `prettier --check .` clean. `src/utils.js` goes 99.22% statements / 98.38% branches → **100% / 100%**; `cli/index.js` sits at 99.4%, the remainder being `main()`'s catch. No concurrency or isolation risk — `readInput` is synchronous and holds no shared state, and the `fs` stub is restored in a `finally` while `node:test` runs subtests sequentially and files in separate processes.

## Not addressed here

Pre-existing, unchanged by this PR, now filed as follow-ups:

- #148 — `parseArgs` swallows the next flag when an option value is missing (`-i -o csv` sets `input: "-o"` and silently discards `-o csv`).
- #149 — `--` is not honoured as end-of-options (`-i -- -o csv` yields `input: "--"`).
- #150 — CSV cannot be piped; stdin is always JSON. Documented here rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBCG2Y5PYaXm746kKk1a3P
