### PR TITLE
docs: reconcile the docs with everything resolved since v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A modern, modular JavaScript library for [candlestick pattern](https://en.wikipe
 - ✅ Comprehensive test suite with high coverage (run `npm test` and `npm run coverage`)
 - 🪶 Zero runtime dependencies
 
-> **Requires Node.js >= 20.** Tested in CI on Node 20.x, 22.x and 24.x across Linux, Windows and macOS.
+> **Requires Node.js >= 20.** Tested in CI on Node 20.x, 22.x, 24.x and 26.x across Linux, Windows and macOS.
 
 ---
 
@@ -586,7 +586,7 @@ const dojis = doji(precomputed);
 
 `patternChain` handles this internally — no manual call needed there.
 
-Run `npm run bench` for full benchmark results on your hardware. The numbers above were measured on the maintainer's machine and may vary.
+Run `npm run bench` for the full benchmark suite on your hardware.
 
 ---
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -279,4 +279,6 @@ const results = processData(data, { confidence: 0.8 });
 
 ---
 
-**CLI Tool is part of Candlestick v1.1.0+** (Enhanced in v1.2.0 with more patterns, v2.0.0 requires Node.js >= 20)
+**The CLI ships with Candlestick v1.1.0+.** It requires Node.js >= 20; the
+authoritative floor is `engines` in `package.json`, and the tested matrix is in
+[CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,6 +27,60 @@ This roadmap outlines planned features and future directions for the Candlestick
 
 ## Completed
 
+### Unreleased
+
+CLI output and project-tooling fixes on top of v2.1.0.
+
+**Observable when using the CLI:**
+
+- `table` and `csv` output now always populate the type, direction, confidence
+  and strength columns, with no `--metadata` flag required.
+- Table columns widen to their content, so long pattern names no longer break
+  the box borders.
+- `-i -` is honoured as stdin, matching the behaviour of omitting `-i`.
+
+**All changes:**
+
+- feat(cli): always include metadata in `table` and `csv` output, so their fixed
+  columns are never empty ([#141](https://github.com/cm45t3r/candlestick/issues/141))
+- fix(cli): honour `-` as stdin when picking the parser; `-i -` previously read
+  stdin and then failed with `Unsupported file format: .`
+  ([#147](https://github.com/cm45t3r/candlestick/pull/147))
+- fix(cli): size table columns to their content ([#140](https://github.com/cm45t3r/candlestick/pull/140))
+- fix(scripts): run the benchmark without a shell in `update-bench`, and format
+  the README through Prettier after regenerating the table
+  ([#128](https://github.com/cm45t3r/candlestick/pull/128))
+- docs(cli): document `-` as an explicit stdin path in `--help` and the CLI
+  guide, and note that piped input is parsed as JSON ([#147](https://github.com/cm45t3r/candlestick/pull/147))
+- docs: refresh the README benchmark table and record the date, Node version and
+  hardware it came from ([#136](https://github.com/cm45t3r/candlestick/issues/136))
+- docs(streaming): replace the unsupported "~70% memory reduction" claim with a
+  measured comparison ([#135](https://github.com/cm45t3r/candlestick/issues/135))
+- docs(contributing): pin the `.nvmrc` floor to 20.19 and explain the
+  `EBADENGINE` warning ([#143](https://github.com/cm45t3r/candlestick/pull/143))
+- ci: test on Node 26.x; CI matrix is now 20.x / 22.x / 24.x / 26.x across
+  Linux, Windows and macOS ([#145](https://github.com/cm45t3r/candlestick/pull/145))
+- ci: remove the GitHub Packages publish workflow, which could not work for an
+  unscoped package name ([#129](https://github.com/cm45t3r/candlestick/issues/129))
+- ci: run CodeQL on `main` instead of the non-existent `master` branch
+  ([#132](https://github.com/cm45t3r/candlestick/pull/132))
+- chore: pin `.nvmrc` to Node 20 to match `engines` ([#123](https://github.com/cm45t3r/candlestick/issues/123))
+- chore: exclude the generated `CHANGELOG.md` from Prettier
+  ([#130](https://github.com/cm45t3r/candlestick/issues/130))
+- chore: silence `no-console` in `update-bench` like its peers
+  ([#137](https://github.com/cm45t3r/candlestick/pull/137))
+- chore(deps): bump `c8` to 12 so coverage runs on Node 26
+  ([#143](https://github.com/cm45t3r/candlestick/pull/143))
+- test: cover the first-candle shadow guards in the three-candle patterns
+  ([#144](https://github.com/cm45t3r/candlestick/pull/144))
+- test: cover the stdin branch of `readInput` and `validateOHLCArray`'s catch,
+  taking `src/utils.js` to 100% statements and branches ([#147](https://github.com/cm45t3r/candlestick/pull/147))
+
+Known gaps, tracked for a later release: [#148](https://github.com/cm45t3r/candlestick/issues/148) (`parseArgs`
+swallows the next flag when an option value is missing), [#149](https://github.com/cm45t3r/candlestick/issues/149)
+(`--` is not honoured as end-of-options) and [#150](https://github.com/cm45t3r/candlestick/issues/150) (CSV cannot
+be piped; stdin is always parsed as JSON).
+
 ### v2.1.0 (2026-09-11)
 
 Streaming correctness release. Three changes are observable through the public
@@ -63,6 +117,11 @@ API — see "Upgrading to v2.1" in the README before updating.
 
 - 3 new patterns: Marubozu (1-candle), Spinning Top (1-candle), Tweezers Top/Bottom (2-candle)
 - Streaming API (`streaming.createStream`, `streaming.processLargeDataset`) with ~70% memory reduction
+  <br>_Correction: the ~70% figure was never substantiated and is kept here only
+  as the record of what v1.2.0 claimed. The reduction measured later is far
+  larger — 41.9 MB to 0.2 MB on 200,000 candles — because resident memory is
+  bounded by `chunkSize` rather than the dataset. See the README streaming
+  section ([#135](https://github.com/cm45t3r/candlestick/issues/135))._
 - Property-based testing with fast-check (1000+ generated OHLC scenarios)
 - Test suite: 306 tests, 99.75% line coverage, 97.63% branch coverage
 - Benchmark suite with throughput metrics (59K+ candles/sec)


### PR DESCRIPTION
Documentation audit against everything resolved since v2.1.0. Four inconsistencies, no behaviour changes.

## 1. README contradicted CONTRIBUTING on the Node matrix

#145 added Node 26 to CI and updated `CONTRIBUTING.md`, but not the README:

| Source | Claimed |
| --- | --- |
| `README.md:25` (before) | `20.x, 22.x and 24.x` |
| `CONTRIBUTING.md:23` | `20.x, 22.x, 24.x and 26.x` |
| `.github/workflows/node.js.yml:17` | `[20.x, 22.x, 24.x, 26.x]` |

The workflow is authoritative, so README was both wrong and understated support. Fixed.

## 2. `ROADMAP.md` had no Unreleased section

Nineteen commits have landed since the `v2.1.0` tag with no entry in any hand-maintained doc. `CHANGELOG.md` is generated at release time, so stopping at v2.1.0 is correct there — it will pick these up at the next release. `ROADMAP.md` is hand-written and was simply missing them.

All nineteen are now recorded, with the three **observable through the CLI** called out separately instead of being buried in a flat list:

- `table` and `csv` always populate type, direction, confidence and strength — no `--metadata` needed (#141)
- table columns size to their content, so long pattern names cannot break the box borders (#140)
- `-i -` is honoured as stdin (#147)

The three gaps found while reviewing #147 — #148, #149, #150 — are linked so they read as tracked rather than unnoticed.

## 3. The superseded `~70%` memory figure

#135 found the "~70% memory reduction" claim unsubstantiated, and the README now carries a measured comparison (41.9 MB → 0.2 MB on 200,000 candles — a far larger reduction than 70%). The figure still stood unmarked in the v1.2.0 release notes.

Annotated rather than deleted: shipped release notes are a record of what that release claimed, so the original wording stays and the correction sits underneath with a link to #135.

## 4. Stale version framing

- `docs/CLI_GUIDE.md` footer still read "v2.0.0 requires Node.js >= 20" at v2.1.0 — stale by construction. It now points at `engines` and CONTRIBUTING instead of restating a version that has to be hand-bumped.
- The README benchmark section stated its caveat twice: a precise provenance paragraph (date, Node version, CPU, RAM, OS) and then a vaguer "measured on the maintainer's machine and may vary". The precise one stays; the second is reduced to the command it exists to give.

## Verified, not assumed

Everything else resolved recently was checked against the code and found already accurate:

- The `CLI_GUIDE` table sample **reproduces byte-for-byte** — rendered through `outputTable` and diffed; only a leading newline differs. The CSV sample matches exactly too.
- **Option parity is complete**: every `--flag` in `--help` appears in `CLI_GUIDE` and vice versa, checked both directions.
- The three "observable" claims above were re-run against the real CLI before being written down, including confirming all five table border lines stay 74 chars wide when `bullishInvertedHammer` widens the Pattern column from 19 to 21.
- #129/#133: zero stale GitHub Packages references remain.
- #123/#131: `.nvmrc` (20.19) is consistent with `engines` (>=20), and the patch pin plus `EBADENGINE` warning are explained.
- #115/#119/#117/#121/#122: README "Upgrading to v2.1" covers all three observable streaming changes.
- "18 patterns across 29 variants" matches `allPatterns.length === 29`.
- Every `#NNN` link added here was resolved against the API.

450/450 tests pass, `eslint` clean, `prettier --check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBCG2Y5PYaXm746kKk1a3P
